### PR TITLE
Use FP for controls on conversion registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ will be registered for a given reporting origin through an HTTP GET to
 the reporting origin that redirects to a [.well-known](https://tools.ietf.org/html/rfc5785)
 location. It is required to be the result of a redirect so that the
 reporting origin can make server-side decisions about when attribution
-reports should trigger. Conversions can only be registered in the main
-document.
+reports should trigger.
+
+Conversion registration requires the `conversion-measurement` Feature Policy to be enabled in the context the request is made. As described in [Publisher Controls for Impression Declaration](#publisher-controls-for-impression-declaration), this Feature Policy will be enabled default in the top-level context and in same-origin children, but disabled in cross-origin children.
 
 Today, conversion pixels are frequently used to register conversions on
 advertiser pages. These can be repurposed to register conversions in


### PR DESCRIPTION
Removes main frame restriction on conversion registration in favor of FP controls, as described on #42