### PR TITLE
Add a few more algorithms for impression / conversion construction

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,7 +44,7 @@ and conversion registration requests.
 
 # Fetch monkeypatches # {#fetch-monkeypatches}
 
-TODO: Patch into fetch for cancelling requests redirected to the .well-known
+Issue: Patch into fetch for cancelling requests redirected to the .well-known
 conversion domain.
 
 # HTML monkeypatches # {#html-monkeypatches}
@@ -60,23 +60,23 @@ partial interface HTMLAnchorElement {
 };
 </pre>
 
-The <dfn for="a" dfn-type="element-attr">conversiondestination</dfn> is the
+The <dfn for="a" element-attr>conversiondestination</dfn> is the
 declared destination [=scheme-and-registrable-domain=] of the anchor for
 purposes of conversion measurement
 
-The <dfn for="a" dfn-type="element-attr">impressiondata</dfn> is a string
+The <dfn for="a" element-attr>impressiondata</dfn> is a string
 containing information about the `impression tag` and will be supplied in the
 `conversion report`.
 
 The <dfn for="a" element-attr>reportingorigin</dfn> declares the
 intended [=origin=] to send the `conversion report` for this impression.
 
-The <dfn for="a" dfn-type="element-attr">impressionexpiry</dfn> is the amount
+The <dfn for="a" element-attr>impressionexpiry</dfn> is the amount
 of time in milliseconds the impression should be considered for conversion
 measurement and reporting reporting.
 
 
-TODO: Need monkey patches passing impression data in navigation, and a mechanism
+Issue: Need monkey patches passing impression data in navigation, and a mechanism
 for validating the resulting document matches the conversiondestination.
 
 # Structures # {#structures}
@@ -131,37 +131,47 @@ A conversion report is a [=struct=] with the following items:
 
 # Algorithms # {#algorithms}
 
+<h3 algorithm id="parsing-conversion-destination">Parsing a conversion destination</h3>
+
+To <dfn>parse a conversion destination</dfn> from an <{a}> tag |anchor|,
+1. Let |url| be the result of running the [=URL parser=] on the value of
+    the |anchor|'s <{a/conversiondestination}>.
+1. Return the result of [=obtain a site|obtaining a site=] from |url|'s
+    [=url/origin=].
+
 <h3 algorithm id="creating-impression">Activating an impression</h3>
 
 To <dfn>activate an impression</dfn> from an <{a}> tag |anchor|,
+1. Let |currentTime| be the current time.
 1. Let |impression| be a new [=impression=] struct whose items are:
 
 : [=impression/impression source=]
 :: |anchor|'s [=relevant settings object=]'s [=environment/top-level origin=].
 : [=impression/impression data=]
-:: The result of applying [=parsing conversion data=] to |anchor|'s <{a/impressiondata}>
-    attribute.
+:: The result of applying [=parsing conversion data=] to |anchor|'s
+    <{a/impressiondata}> attribute.
 : [=impression/conversion destination=]
-:: The result of parsing <{a/conversiondestination}> as a site.
+:: The result of running [=parse a conversion destination=] on |anchor|.
 : [=impression/reporting endpoint=]
-:: The result of [=obtain a site|obtaining a site=] from the result of parsing
-    <{a/reportingorigin}> as an origin.
+:: The [=url/origin=] of the result of running the [=URL parser=] on the value
+    of |anchor|'s <{a/reportingorigin}> attribute.
 : [=impression/expiry=]
-:: The point in time <{a/impressionexpiry}> milliseconds in the future.
+:: |currentTime| +  <{a/impressionexpiry}> milliseconds.
 : [=impression/impression time=]
-:: The current time.
+:: |currentTime|.
 
-TODO: How to store the impression
+Issue: Need to spec how to store the impression.
 
 <h3 algorithm id="creating-a-conversion">Creating a conversion</h3>
 
-To <dfn>create a conversion</dfn> from a [=url=] |url|:
+To <dfn>create a conversion</dfn> from a [=url=] |url| and a
+    [=environment settings object=] |environment|.
 
 : [=conversion/conversion source=]
-:: The current top-level origin.
+:: |environment|'s [=environment/top-level origin=].
 : [=conversion/conversion data=]
 :: The result of applying [=parsing conversion data=] to the value associated with the
-    |conversion-data| field in the URL's query part.
+    |conversion-data| field of |url|'s query part.
 : [=conversion/conversion time=]
 :: Be the current time.
 
@@ -173,11 +183,18 @@ To <dfn>register a conversion</dfn> from a [=request=] |request|, run the follow
 
 1. If |request|'s [=request/current url's=] [=url/path=] is not `.well-known/register-conversion`,
     return.
-1. If the request's [=request/redirect count=] is less than 1, return.
+1. If |request|'s [=request/redirect count=] is less than 1, return.
+1. Let |previousUrl| be the second to last [=URL=] in |request|'s
+    [=request/URL list=].
+1. If |request|'s [=request/current url's=] [=url/origin=] is not [=same origin=] with
+    |previousUrl|'s [=url/origin=], return.
 1. Let |conversionToRegister| be the result of applying [=create a conversion=] from the
     request's [=request/current url=].
 
-TODO: How to store the conversion
+Note: the restriction to require a redirect is needed to ensure that the
+request's origin is aware and in control of the conversion registration.
+
+Issue: Need to spec how to store the conversion.
 
 <h3 algorithm id="parsing-data">Parsing data fields</h3>
 
@@ -198,18 +215,29 @@ the following steps:
 <h3 algorithm id="delivery-time">Establishing report delivery time</h3>
 The <dfn>report delivery time</dfn> for an [=impression=] |impression| and a
 [=conversion/conversion time=] |conversionTime| is the result of the following steps:
-1. Let |conversionTimeAfterImpression| be the difference between the [=conversion/conversion time=] and [=impression/impression time=].
-2. Let |expiryDelta| be the difference between the [=impression/expiry=] and the [=impression/impression time=]
-1. If |timeDelta| <= (2 days - 1 hour), return [=impression/impression time=] + 2 days
-1. If
+1. Let |conversionTimeAfterImpression| be the difference between the
+    [=conversion/conversion time=] and [=impression/impression time=].
+2. Let |expiryDelta| be the difference between the [=impression/expiry=] and
+    the [=impression/impression time=]
+
+<dl class="switch">
+<dt>If |conversionTimeAfterImpression| <= (2 days - 1 hour)</dt>
+<dd>return [=impression/impression time=] + 2 days.</dd>
+
+<dt>
+If
     - |expiryDelta| > (2 days - 1 hour) and
     - |expiryDelta| < (7 days - 1 hour) and
-    - |timeDelta| <= |expiryDelta|
+    - |conversionTimeAfterImpression| <= |expiryDelta|
+</dt>
+<dd>return the [=impression/expiry=] + 1 hour.</dd>
 
+<dt>If |conversionTimeAfterImpression| <= (7 days - 1 hour)</dt>
+<dd>return [=impression/impression time=] + 7 days</dd>
 
-    return the [=impression/expiry=] + 1 hour.
-1. If |timeDelta| <= (7 days - 1 hour), return [=impression/impression time=] + 7 days
-1. return the [=impression/expiry=] + 1 hour.
+<dt>Otherwise</dt>
+<dd>return the [=impression/expiry=] + 1 hour.</dd>
+</dl>
 
 <h3 algorithm id="queuing-report">Queuing a conversion report</h3>
 TODO

--- a/index.bs
+++ b/index.bs
@@ -96,6 +96,8 @@ An impression is a [=struct=] with the following items:
 :: An [=url/origin=].
 : <dfn>expiry</dfn>
 :: A point in time.
+: <dfn>impression time</dfn>
+:: A point in time.
 
 </ul>
 
@@ -108,6 +110,8 @@ A conversion is a [=struct=] with the following items:
 :: An [=url/origin=].
 : <dfn>conversion data</dfn>
 :: A [=string=].
+: <dfn>conversion time</dfn>
+:: A point in time.
 
 </ul>
 
@@ -143,7 +147,9 @@ create a new [=impression=] struct whose items are:
 :: The result of [=origin/obtaining a site=] from the result of parsing
     <{a/reportingorigin}> as an origin.
 : [=impression/expiry=]
-:: Be a timestamp <{a/impressionexpiry}> milliseconds in the future
+:: Be a timestamp <{a/impressionexpiry}> milliseconds in the future.
+: [=impression/impression time=]
+:: Be the current time.
 
 TODO: How to store the impression
 
@@ -156,6 +162,8 @@ To <dfn>create a conversion</dfn> from a [=url=]:
 : [=conversion/conversion data=]
 :: The result of applying [=parsing conversion data=] to the value associated with the
     |conversion-data| field in the URL's query part.
+: [=conversion/conversion time=]
+:: Be the current time.
 
 TODO: Formalize how to parse the query similar to URLSearchParams.
 
@@ -188,7 +196,12 @@ the following steps:
 1. Return |encodedOutput|.
 
 <h3 algorithm id="delivery-time">Establishing report delivery time</h3>
-TODO
+To <dfn>establish report delivery time</dfn> given an [=impression=] and a
+[=conversion/conversion time=], run the following steps:
+1. Let |timeDelta| be the difference between the [=conversion/conversion time=] and [=impression/impression time=].
+1. If |timeDelta| <= (2 days - 1 hour), return [=impression/impression time=] + 2 days
+1. If |timeDelta| <= (7 days - 1 hour), return [=impression/impression time=] + 7 days
+1. return the [=impression/expiry=]
 
 <h3 algorithm id="queuing-report">Queuing a conversion report</h3>
 TODO

--- a/index.bs
+++ b/index.bs
@@ -199,9 +199,17 @@ the following steps:
 To <dfn>establish report delivery time</dfn> given an [=impression=] and a
 [=conversion/conversion time=], run the following steps:
 1. Let |timeDelta| be the difference between the [=conversion/conversion time=] and [=impression/impression time=].
+2. Let |expiryDelta| be the difference between the [=impression/expiry=] and the [=impression/impression time=]
 1. If |timeDelta| <= (2 days - 1 hour), return [=impression/impression time=] + 2 days
+1. If
+    - |expiryDelta| > (2 days - 1 hour) and
+    - |expiryDelta| < (7 days - 1 hour) and
+    - |timeDelta| <= |expiryDelta|
+
+
+    return the [=impression/expiry=] + 1 hour.
 1. If |timeDelta| <= (7 days - 1 hour), return [=impression/impression time=] + 7 days
-1. return the [=impression/expiry=]
+1. return the [=impression/expiry=] + 1 hour.
 
 <h3 algorithm id="queuing-report">Queuing a conversion report</h3>
 TODO

--- a/index.bs
+++ b/index.bs
@@ -68,7 +68,7 @@ The <dfn for="a" dfn-type="element-attr">impressiondata</dfn> is a string
 containing information about the `impression tag` and will be supplied in the
 `conversion report`.
 
-The <dfn for="a" dfn-type="element-attr">reportingorigin</dfn> declares the
+The <dfn for="a" element-attr>reportingorigin</dfn> declares the
 intended [=origin=] to send the `conversion report` for this impression.
 
 The <dfn for="a" dfn-type="element-attr">impressionexpiry</dfn> is the amount
@@ -133,29 +133,29 @@ A conversion report is a [=struct=] with the following items:
 
 <h3 algorithm id="creating-impression">Activating an impression</h3>
 
-To <dfn>activate an impression</dfn> from an <{a}> tag,
-create a new [=impression=] struct whose items are:
+To <dfn>activate an impression</dfn> from an <{a}> tag |anchor|,
+1. Let |impression| be a new [=impression=] struct whose items are:
 
 : [=impression/impression source=]
-:: The current top frame's [=origin=].
+:: |anchor|'s [=relevant settings object=]'s [=environment/top-level origin=].
 : [=impression/impression data=]
-:: The result of applying [=parsing conversion data=] to the <{a/impressiondata}>
+:: The result of applying [=parsing conversion data=] to |anchor|'s <{a/impressiondata}>
     attribute.
 : [=impression/conversion destination=]
 :: The result of parsing <{a/conversiondestination}> as a site.
 : [=impression/reporting endpoint=]
-:: The result of [=origin/obtaining a site=] from the result of parsing
+:: The result of [=obtain a site|obtaining a site=] from the result of parsing
     <{a/reportingorigin}> as an origin.
 : [=impression/expiry=]
-:: Be a timestamp <{a/impressionexpiry}> milliseconds in the future.
+:: The point in time <{a/impressionexpiry}> milliseconds in the future.
 : [=impression/impression time=]
-:: Be the current time.
+:: The current time.
 
 TODO: How to store the impression
 
 <h3 algorithm id="creating-a-conversion">Creating a conversion</h3>
 
-To <dfn>create a conversion</dfn> from a [=url=]:
+To <dfn>create a conversion</dfn> from a [=url=] |url|:
 
 : [=conversion/conversion source=]
 :: The current top-level origin.
@@ -165,13 +165,13 @@ To <dfn>create a conversion</dfn> from a [=url=]:
 : [=conversion/conversion time=]
 :: Be the current time.
 
-TODO: Formalize how to parse the query similar to URLSearchParams.
+Issue: Formalize how to parse the query similar to URLSearchParams.
 
 <h3 algorithm id="register-conversion">Register a conversion</h3>
 
-To <dfn>register a conversion</dfn> from a fetch [=request=], run the following steps:
+To <dfn>register a conversion</dfn> from a [=request=] |request|, run the following steps:
 
-1. If the requests [=request/current url's=] [=url/path=] is not `.well-known/register-conversion`,
+1. If |request|'s [=request/current url's=] [=url/path=] is not `.well-known/register-conversion`,
     return.
 1. If the request's [=request/redirect count=] is less than 1, return.
 1. Let |conversionToRegister| be the result of applying [=create a conversion=] from the
@@ -196,9 +196,9 @@ the following steps:
 1. Return |encodedOutput|.
 
 <h3 algorithm id="delivery-time">Establishing report delivery time</h3>
-To <dfn>establish report delivery time</dfn> given an [=impression=] and a
-[=conversion/conversion time=], run the following steps:
-1. Let |timeDelta| be the difference between the [=conversion/conversion time=] and [=impression/impression time=].
+The <dfn>report delivery time</dfn> for an [=impression=] |impression| and a
+[=conversion/conversion time=] |conversionTime| is the result of the following steps:
+1. Let |conversionTimeAfterImpression| be the difference between the [=conversion/conversion time=] and [=impression/impression time=].
 2. Let |expiryDelta| be the difference between the [=impression/expiry=] and the [=impression/impression time=]
 1. If |timeDelta| <= (2 days - 1 hour), return [=impression/impression time=] + 2 days
 1. If

--- a/index.bs
+++ b/index.bs
@@ -145,35 +145,36 @@ To <dfn>activate an impression</dfn> from an <{a}> tag |anchor|,
 1. Let |currentTime| be the current time.
 1. Let |impression| be a new [=impression=] struct whose items are:
 
-: [=impression/impression source=]
-:: |anchor|'s [=relevant settings object=]'s [=environment/top-level origin=].
-: [=impression/impression data=]
-:: The result of applying [=parsing conversion data=] to |anchor|'s
-    <{a/impressiondata}> attribute.
-: [=impression/conversion destination=]
-:: The result of running [=parse a conversion destination=] on |anchor|.
-: [=impression/reporting endpoint=]
-:: The [=url/origin=] of the result of running the [=URL parser=] on the value
-    of |anchor|'s <{a/reportingorigin}> attribute.
-: [=impression/expiry=]
-:: |currentTime| +  <{a/impressionexpiry}> milliseconds.
-: [=impression/impression time=]
-:: |currentTime|.
+    : [=impression/impression source=]
+    :: |anchor|'s [=relevant settings object=]'s [=environment/top-level origin=].
+    : [=impression/impression data=]
+    :: The result of applying [=parsing conversion data=] to |anchor|'s
+        <{a/impressiondata}> attribute.
+    : [=impression/conversion destination=]
+    :: The result of running [=parse a conversion destination=] on |anchor|.
+    : [=impression/reporting endpoint=]
+    :: The [=url/origin=] of the result of running the [=URL parser=] on the value
+        of |anchor|'s <{a/reportingorigin}> attribute.
+    : [=impression/expiry=]
+    :: |currentTime| +  <{a/impressionexpiry}> milliseconds.
+    : [=impression/impression time=]
+    :: |currentTime|.
 
-Issue: Need to spec how to store the impression.
+1. Issue: Need to spec how to store the impression.
 
 <h3 algorithm id="creating-a-conversion">Creating a conversion</h3>
 
-To <dfn>create a conversion</dfn> from a [=url=] |url| and a
-    [=environment settings object=] |environment|.
+To <dfn>create a conversion</dfn> from a [=url=] |url| and an
+[=environment settings object=] |environment|, return a new [=conversion=]
+struct with the items:
 
-: [=conversion/conversion source=]
-:: |environment|'s [=environment/top-level origin=].
-: [=conversion/conversion data=]
-:: The result of applying [=parsing conversion data=] to the value associated with the
-    |conversion-data| field of |url|'s query part.
-: [=conversion/conversion time=]
-:: Be the current time.
+    : [=conversion/conversion source=]
+    :: |environment|'s [=environment/top-level origin=].
+    : [=conversion/conversion data=]
+    :: The result of applying [=parsing conversion data=] to the value associated with the
+        `"conversion-data"` field of |url|'s [=url/query=].
+    : [=conversion/conversion time=]
+    :: The current time.
 
 Issue: Formalize how to parse the query similar to URLSearchParams.
 
@@ -191,10 +192,10 @@ To <dfn>register a conversion</dfn> from a [=request=] |request|, run the follow
 1. Let |conversionToRegister| be the result of applying [=create a conversion=] from the
     request's [=request/current url=].
 
-Note: the restriction to require a redirect is needed to ensure that the
-request's origin is aware and in control of the conversion registration.
+    Note: the restriction to require a redirect is needed to ensure that the
+    request's origin is aware and in control of the conversion registration.
 
-Issue: Need to spec how to store the conversion.
+1. Issue: Need to spec how to store the conversion.
 
 <h3 algorithm id="parsing-data">Parsing data fields</h3>
 
@@ -217,27 +218,30 @@ The <dfn>report delivery time</dfn> for an [=impression=] |impression| and a
 [=conversion/conversion time=] |conversionTime| is the result of the following steps:
 1. Let |conversionTimeAfterImpression| be the difference between the
     [=conversion/conversion time=] and [=impression/impression time=].
-2. Let |expiryDelta| be the difference between the [=impression/expiry=] and
+1. Let |expiryDelta| be the difference between the [=impression/expiry=] and
     the [=impression/impression time=]
 
-<dl class="switch">
-<dt>If |conversionTimeAfterImpression| <= (2 days - 1 hour)</dt>
-<dd>return [=impression/impression time=] + 2 days.</dd>
+    Note: |conversionTimeAfterImpression| should always be less than
+    |expiryDelta| because it should not be possible to convert an expired
+    impression.
 
-<dt>
-If
-    - |expiryDelta| > (2 days - 1 hour) and
-    - |expiryDelta| < (7 days - 1 hour) and
-    - |conversionTimeAfterImpression| <= |expiryDelta|
-</dt>
-<dd>return the [=impression/expiry=] + 1 hour.</dd>
+1. If:
+    <dl class="switch">
+    <dt>|conversionTimeAfterImpression| <= (2 days - 1 hour)</dt>
+    <dd>return [=impression/impression time=] + 2 days.</dd>
 
-<dt>If |conversionTimeAfterImpression| <= (7 days - 1 hour)</dt>
-<dd>return [=impression/impression time=] + 7 days</dd>
+    <dt> |expiryDelta| > (2 days - 1 hour)
+        - and |expiryDelta| < (7 days - 1 hour)
+        - and |conversionTimeAfterImpression| <= |expiryDelta|
+    </dt>
+    <dd>return the [=impression/expiry=] + 1 hour.</dd>
 
-<dt>Otherwise</dt>
-<dd>return the [=impression/expiry=] + 1 hour.</dd>
-</dl>
+    <dt>|conversionTimeAfterImpression| <= (7 days - 1 hour)</dt>
+    <dd>return [=impression/impression time=] + 7 days</dd>
+
+    <dt>Otherwise</dt>
+    <dd>return the [=impression/expiry=] + 1 hour.</dd>
+    </dl>
 
 <h3 algorithm id="queuing-report">Queuing a conversion report</h3>
 TODO

--- a/index.bs
+++ b/index.bs
@@ -13,6 +13,9 @@ Markup Shorthands: markdown on
 Complain About: accidental-2119 on, missing-example-ids on
 Assume Explicit For: on
 </pre>
+<pre class=link-defaults>
+spec:html; type:element; text:a
+</pre>
 
 Introduction {#intro}
 =====================
@@ -52,7 +55,7 @@ Rewrite the anchor element to accept the following attributes:
 partial interface HTMLAnchorElement {
     [CEReactions, Reflect] attribute DOMString conversiondestination;
     [CEReactions, Reflect] attribute DOMString impressiondata;
-    [CEReactions, Reflect] attribute DOMString reportingdomain;
+    [CEReactions, Reflect] attribute DOMString reportingorigin;
     [CEReactions, Reflect] attribute unsigned long long impressionexpiry;
 };
 </pre>
@@ -65,7 +68,7 @@ The <dfn for="a" dfn-type="element-attr">impressiondata</dfn> is a string
 containing information about the `impression tag` and will be supplied in the
 `conversion report`.
 
-The <dfn for="a" dfn-type="element-attr">reportingdomain</dfn> declares the
+The <dfn for="a" dfn-type="element-attr">reportingorigin</dfn> declares the
 intended [=origin=] to send the `conversion report` for this impression.
 
 The <dfn for="a" dfn-type="element-attr">impressionexpiry</dfn> is the amount
@@ -124,22 +127,57 @@ A conversion report is a [=struct=] with the following items:
 
 # Algorithms # {#algorithms}
 
-<h3 algorithm id="creating-conversion">Creating a conversion</h3>
-TODO
+<h3 algorithm id="creating-impression">Activating an impression</h3>
 
-<h3 algorithm id="creating-impression">Creating an impression</h3>
-TODO
+To <dfn>activate an impression</dfn> from an <{a}> tag,
+create a new [=impression=] struct whose items are:
+
+: [=impression/impression source=]
+:: The current top frame's [=origin=].
+: [=impression/impression data=]
+:: The result of applying [=parsing conversion data=] to the <{a/impressiondata}>
+    attribute.
+: [=impression/conversion destination=]
+:: The result of parsing <{a/conversiondestination}> as a site.
+: [=impression/reporting endpoint=]
+:: The result of [=origin/obtaining a site=] from the result of parsing
+    <{a/reportingorigin}> as an origin.
+: [=impression/expiry=]
+:: Be a timestamp <{a/impressionexpiry}> milliseconds in the future
+
+TODO: How to store the impression
+
+<h3 algorithm id="creating-a-conversion">Creating a conversion</h3>
+
+To <dfn>create a conversion</dfn> from a [=url=]:
+
+: [=conversion/conversion source=]
+:: The current top-level origin.
+: [=conversion/conversion data=]
+:: The result of applying [=parsing conversion data=] to the value associated with the
+    |conversion-data| field in the URL's query part.
+
+TODO: Formalize how to parse the query similar to URLSearchParams.
 
 <h3 algorithm id="register-conversion">Register a conversion</h3>
-TODO
 
-<h3 algorithm id="parsing-the-metadata">Parsing the metadata</h3>
+To <dfn>register a conversion</dfn> from a fetch [=request=], run the following steps:
+
+1. If the requests [=request/current url's=] [=url/path=] is not `.well-known/register-conversion`,
+    return.
+1. If the request's [=request/redirect count=] is less than 1, return.
+1. Let |conversionToRegister| be the result of applying [=create a conversion=] from the
+    request's [=request/current url=].
+
+TODO: How to store the conversion
+
+<h3 algorithm id="parsing-data">Parsing data fields</h3>
 
 This section defines how to parse and extract both
 [=impression/impression data=] and [=conversion/conversion data=] from a
 [=string=] |input| and a unsigned long long |maxData|.
 
-<dfn>Parsing metadata</dfn> from |input| with |maxData| returns the result of
+<dfn>Parsing conversion data</dfn> from |input| with |maxData| returns the result of
 the following steps:
 
 1. Let |decodedInput| be the result of decoding |input| as a base-16 integer.


### PR DESCRIPTION
The PR adds a few algorithms for how to create impression / conversion structs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/pull/58.html" title="Last updated on Oct 13, 2020, 10:40 PM UTC (aac21ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/58/50aeae6...aac21ab.html" title="Last updated on Oct 13, 2020, 10:40 PM UTC (aac21ab)">Diff</a>