### PR TITLE
Fix typo in iframe allow attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ In order to prevent arbitrary third parties from registering impressions without
 API will need to be enabled in child contexts by a new [Feature Policy](https://w3c.github.io/webappsec-feature-policy/):
 
 ```
-<iframe src="https://advertiser.test" allow="conversion-measurement ‘src’)">
+<iframe src="https://advertiser.test" allow="conversion-measurement ‘src’">
 
 <a … id="impressionTag" reportingorigin="https://ad-tech.com"></a>
 


### PR DESCRIPTION
There is an extraneous parenthesis in the example iframe tag.