### PR TITLE
Remove "impression"/"conversion" from API surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,11 @@ Glossary
 
 -   **Advertiser**: Purchaser of ad slots, conversions happen on advertiser sites
 
--   **Impression**: Click/view of an ad, equivalent to an attribution source.
-
 -   **Conversion**: The completion of a meaningful (advertiser specified) user action on the advertiser's web site by a user who has previously interacted with an ad from that advertiser.
 
 -   **Event-level data**: Data that can be tied back to a specific low-level event; not aggregated
 
--   **Click-through-conversion (CTC)**: A conversion attributed to an impression that was clicked
+-   **Click-through-conversion (CTC)**: A conversion attributed to an ad click
 
 Motivation
 ----------

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ In order to prevent arbitrary third parties from registering sources without the
 ```
 <iframe src="https://advertiser.test" allow="attribution-reporting ‘src’">
 
-<a … id="impressionTag" attributionreportto="https://ad-tech.com"></a>
+<a … id="..." attributionreportto="https://ad-tech.com"></a>
 
 </iframe>
 ```

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ but also to whether attribution was triggered in the first place. That is:
 
 -   With some probability *q*, sources that have not been triggered will be triggered, and given random `trigger-data`.
 
-The biggest problem with this scheme is that triggering attribution sources, in
+The biggest problem with this scheme is that attribution trigger events are, in
 general, *rare*. Additionally, different advertisers can have wildly
 different *attribution rates*. These two facts make it very hard to pick
 a *q* that works reliably without drowning out the signal with noise.

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ data could be used to link advertiser identity with publisher
 identity.
 
 Mitigations against this are to provide only coarse information (only a
-few bits at a time), and introduce some noise to the trigger-data. Even
+few bits at a time), and introduce some noise to the trigger data. Even
 sophisticated attackers will therefore need to invoke the API many times
 (through many clicks) to join identity between sites with high
 confidence.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ from 0-5 (~2.6 bits of information)
 
 ### Trigger attribution algorithm
 
-When the browser receives a attriubtion trigger redirect on a URL matching
+When the browser receives a attribution trigger redirect on a URL matching
 the `attributeon` eTLD+1, it looks up all sources in storage that
 match <`attributionreportto`, `attributeon`>.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Event-Level Attribution Measurement API Explainer
+
+Click Through Attribution Reporting API Explainer
 ============
 
 This document is an explainer for a potential new web platform feature
@@ -166,11 +167,10 @@ associated reporting origin.
 
 ### Publisher-side Controls for Source Declaration
 
-In order to prevent arbitrary third parties from registering sources without the publisher’s knowledge, the Attribution Measurement
-API will need to be enabled in child contexts by a new [Feature Policy](https://w3c.github.io/webappsec-feature-policy/):
+In order to prevent arbitrary third parties from registering sources without the publisher’s knowledge, the Attribution Reporting API will need to be enabled in child contexts by a new [Feature Policy](https://w3c.github.io/webappsec-feature-policy/):
 
 ```
-<iframe src="https://advertiser.test" allow="attribution-measurement ‘src’">
+<iframe src="https://advertiser.test" allow="attribution-reporting ‘src’">
 
 <a … id="impressionTag" attributionreportto="https://ad-tech.com"></a>
 
@@ -187,15 +187,14 @@ Triggering Attribution
 This API will use a mechanism for triggering attribution similar to the
 [Ad Click Attribution Proposal](https://wicg.github.io/ad-click-attribution/index.html#legacytriggering).
 
-Attribution must be triggered on an page . Attribution is
+Attribution triggering is meant to occur on `attributeon` pages. Attribution is
 triggered for a given `reportto` origin on a given `attributeon` through an HTTP GET to
 the origin, that redirects to a [.well-known](https://tools.ietf.org/html/rfc5785)
 location.
-This redirect is useful, because this mechanism enables the reporting origin to make server-side decisions about when attribution
-reports should trigger.
+This redirect is useful, because this mechanism enables the reporting origin to make server-side decisions about when attribution reports should trigger.
 Note that `.well-known` is only used to register a path that the browser will understand; it shouldn't point to any actual resource, since the request will be cancelled internally.
 
-Triggering attribution requires the `attribution-measurement` Feature Policy to be enabled in the context the request is made. As described in [Publisher Controls for Source Declaration](#publisher-side-controls-for-source-declaration), this Feature Policy will be enabled by default in the top-level context and in same-origin children, but disabled in cross-origin children.
+Triggering attribution requires the `attribution-reporting` Feature Policy to be enabled in the context the request is made. As described in [Publisher Controls for Source Declaration](#publisher-side-controls-for-source-declaration), this Feature Policy will be enabled by default in the top-level context and in same-origin children, but disabled in cross-origin children.
 
 Today, conversion pixels are frequently used to register conversions on
 advertiser pages. These can be repurposed to trigger attribution in
@@ -390,7 +389,7 @@ Within the iframe, `toasters.com` code annotates their anchor tags to use
 the `ad-tech.com` reporting origin, and uses a source data value that allows
 `ad-tech.com` to identify the ad click (12345678)
 ```
-<iframe src="https://ad-tech-3p.test/show-some-ad" allow="attribution-measurement ‘src’ (https://ad-tech.com)">
+<iframe src="https://ad-tech-3p.test/show-some-ad" allow="attribution-reporting ‘src’ (https://ad-tech.com)">
 ...
 <a 
   href="https://toasters.com/purchase"

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ When the browser receives a attribution trigger redirect on a URL matching
 the `attributeon` eTLD+1, it looks up all sources in storage that
 match <`attributionreportto`, `attributeon`>.
 
-The most recent matching source is given a `credit` of value 100. All other matching sources are given a `credit` of value of 0.
+The most recent matching source is given a `credit` of value 100. All other matching sources are given a `credit` of value 0.
 
 For each matching source, schedule a report. To schedule a report,
 the browser will store

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ WindowProxy? open(
   optional AttributionSourceParams attribution_source_params)
 ```
 
-`AttributionSourceParams` is a dictionary which contains the same attributes used by attribution source anchor tag:
+`AttributionSourceParams` is a dictionary which contains the same attributes used by attribution source anchor tags:
 
 ```
 dictionary AttributionSourceParams {

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ to trigger attribution for all matching sources.
 The browser will treat redirects to a URL of the form:
 `https://<attributionreportto>/.well-known/trigger-attribution[?data=<data>]`
 
-as a special request, where optional data associated with the event that trigged attrbution is stored in a query parameter.
+as a special request, where optional data associated with the event that triggered attribution is stored in a query parameter.
 
 When the special redirect is detected, the browser will schedule an attribution
 report as detailed in [Trigger attribution algorithm](#trigger-attribution-algorithm).

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ body:
 {
   "sourceData": "12345678",
   "triggerData": "2",
-  "creidt": 100
+  "credit": 100
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ This API will use a mechanism for triggering attribution similar to the
 [Ad Click Attribution Proposal](https://wicg.github.io/ad-click-attribution/index.html#legacytriggering).
 
 Attribution triggering is meant to occur on `attributeon` pages. Attribution is
-triggered for a given `reportto` origin on a given `attributeon` through an HTTP GET to
+triggered for a given `reportto` origin on a given `attributeon` page through an HTTP GET to
 the origin, that redirects to a [.well-known](https://tools.ietf.org/html/rfc5785)
 location.
 This redirect is useful, because this mechanism enables the reporting origin to make server-side decisions about when attribution reports should trigger.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-Click Through Conversion Measurement Event-Level API Explainer
+Event-Level Attribution Measurement API Explainer
 ============
 
 This document is an explainer for a potential new web platform feature
@@ -16,35 +15,31 @@ See the explainer on [aggregate measurement](AGGREGATE.md) for a potential exten
   - [Glossary](#glossary)
   - [Motivation](#motivation)
   - [Prior Art](#prior-art)
-- [Click Through Conversion Measurement Event-Level API Explainer](#click-through-conversion-measurement-event-level-api-explainer)
-  - [Glossary](#glossary)
-  - [Motivation](#motivation)
-  - [Prior Art](#prior-art)
 - [Overview](#overview)
-  - [Impression Declaration](#impression-declaration)
-    - [Registering impressions for anchor tag navigations](#registering-impressions-for-anchor-tag-navigations)
-    - [Registering impressions for window.open() navigations](#registering-impressions-for-windowopen-navigations)
-    - [Handling an impression event](#handling-an-impression-event)
-    - [Publisher-side Controls for Impression Declaration](#publisher-side-controls-for-impression-declaration)
-  - [Conversion Registration](#conversion-registration)
+  - [Attribution Source Declaration](#attribution-source-declaration)
+    - [Registering attribution sources for anchor tag navigations](#registering-attribution-sources-for-anchor-tag-navigations)
+    - [Registering sources for window.open() navigations](#registering-sources-for-windowopen-navigations)
+    - [Handling an attribution source](#handling-an-attribution-source)
+    - [Publisher-side Controls for Source Declaration](#publisher-side-controls-for-source-declaration)
+  - [Triggering Attribution](#triggering-attribution)
     - [Data limits and noise](#data-limits-and-noise)
-    - [Register a conversion algorithm](#register-a-conversion-algorithm)
-    - [Multiple impressions for the same conversion (Multi-touch)](#multiple-impressions-for-the-same-conversion-multi-touch)
-    - [Multiple conversions for the same impression](#multiple-conversions-for-the-same-impression)
+    - [Trigger attribution algorithm](#trigger-attribution-algorithm)
+    - [Multiple sources for the same trigger (Multi-touch)](#multiple-sources-for-the-same-trigger-multi-touch)
+    - [Triggering attribution multiple times for the same source](#triggering-attribution-multiple-times-for-the-same-source)
   - [Sending Scheduled Reports](#sending-scheduled-reports)
-    - [Conversion Reports](#conversion-reports)
+    - [Attribution Reports](#attribution-reports)
   - [Data Encoding](#data-encoding)
 - [Sample Usage](#sample-usage)
 - [Privacy Considerations](#privacy-considerations)
-  - [Conversion Data](#conversion-data)
-  - [Conversion Delay](#conversion-delay)
-  - [Limits on the number of conversion pixels](#limits-on-the-number-of-conversion-pixels)
+  - [Trigger Data](#trigger-data)
+  - [Reporting Delay](#reporting-delay)
+  - [Limits on the number of attribution triggers](#limits-on-the-number-of-attribution-triggers)
   - [Clearing Site Data](#clearing-site-data)
   - [Reporting cooldown](#reporting-cooldown)
   - [Speculative: Limits based on first party storage](#speculative-limits-based-on-first-party-storage)
-  - [Speculative: Adding noise to the conversion event itself](#speculative-adding-noise-to-the-conversion-event-itself)
+  - [Speculative: Adding noise to the attribution of the source itself](#speculative-adding-noise-to-the-attribution-of-the-source-itself)
 - [Open Questions](#open-questions)
-  - [Multiple Reporting Endpoints Per Conversion](#multiple-reporting-endpoints-per-conversion)
+  - [Multiple Reporting Endpoints Per Attributed Source](#multiple-reporting-endpoints-per-attributed-source)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -55,13 +50,13 @@ Glossary
 
 -   **Advertiser**: Purchaser of ad slots, conversions happen on advertiser sites
 
--   **Impression**: View of an ad
+-   **Impression**: Click/view of an ad, equivalent to an attribution source.
 
 -   **Conversion**: The completion of a meaningful (advertiser specified) user action on the advertiser's web site by a user who has previously interacted with an ad from that advertiser.
 
 -   **Event-level data**: Data that can be tied back to a specific low-level event; not aggregated
 
--   **Click-through-conversion (CTC)**: A conversion credit attributed to an impression that was clicked
+-   **Click-through-conversion (CTC)**: A conversion attributed to an impression that was clicked
 
 Motivation
 ----------
@@ -100,139 +95,138 @@ Brave has published and implemented an [Ads Confirmation Protocol](https://githu
 Overview
 ========
 
-Impression Declaration
+Attribution Source Declaration
 ----------------------
 
-### Registering impressions for anchor tag navigations
+### Registering attribution sources for anchor tag navigations
 
-An impression tag is an anchor tag with special attributes:
+An attribution source is an anchor tag with special attributes:
 
-`<a conversiondestination="[eTLD+1]" impressiondata="[string]"
-impressionexpiry=[unsigned long long] reportingorigin="[origin]">`
+`<a attributeon="[eTLD+1]" attributionsourcedata="[string]"
+attributionexpiry=[unsigned long long] attributionreportto="[origin]">`
 
-Impression attributes:
+Attribution source attributes:
 
--   `conversiondestination`: the intended eTLD+1 destination of the ad click.
+-   `attributeon`: the intended eTLD+1 destination of the ad click.
 
--   `impressiondata`: the event-level data associated with this impression. This will be limited to 64 bits of information, [encoded as a hexadecimal string](#data-encoding), but the value can vary for browsers that want a higher level of privacy.
+-   `attributionsourcedata`: the event-level data associated with this source. This will be limited to 64 bits of information, [encoded as a hexadecimal string](#data-encoding), but the value can vary for browsers that want a higher level of privacy.
 
--   `impressionexpiry`: (optional) expiry in milliseconds for when the impression should be deleted. Default is 30 days, with a maximum value of 30 days. The maximum expiry can also vary between browsers.
+-   `attributionexpiry`: (optional) expiry in milliseconds for when the source should be deleted. Default is 30 days, with a maximum value of 30 days. The maximum expiry can also vary between browsers.
 
--   `reportingorigin`: (optional) the desired endpoint that the conversion report for this impression should go to. Default is the top level origin of the page.
+-   `attributionreportto`: (optional) the desired endpoint that the attribution report for this source should go to. Default is the top level origin of the page.
 
-Clicking on an anchor tag that specifies these attributes will create a new impression event that will be handled according to [Handling an impression event](#handling-an-impression-event)
+Clicking on an anchor tag that specifies these attributes will create a new attribution source that will be handled according to [Handling an attribution source](#handling-an-attribution-source)
 
-### Registering impressions for window.open() navigations
+### Registering sources for window.open() navigations
 
-An impression event can be registered for navigations initiated by [`window.open()`](https://html.spec.whatwg.org/multipage/window-object.html#dom-open).
+An attribution source can be registered for navigations initiated by [`window.open()`](https://html.spec.whatwg.org/multipage/window-object.html#dom-open).
 
-An impression is registered through a new `window.open()` overload:
+A source is registered through a new `window.open()` overload:
 
 ```
 WindowProxy? open(
   optional USVString url = "",
   optional DOMString target = "_blank",
   optional [LegacyNullToEmptyString] DOMString features = "",
-  optional ImpressionParams impression_params)
+  optional AttributionSourceParams attribution_source_params)
 ```
 
-`ImpressionParams` is a dictionary which contains the same impression attributes used by impression anchor tags:
+`AttributionSourceParams` is a dictionary which contains the same attributes used by attribution source anchor tag:
 
 ```
-dictionary ImpressionParams {
-  required DOMString impressionData;
-  required USVString conversionDestination;
-  optional USVString reportingOrigin;
-  optional unsigned long impressionExpiry;
+dictionary AttributionSourceParams {
+  required DOMString attributionSourceData;
+  required USVString attributeOn;
+  optional USVString attributionReportTo;
+  optional unsigned long attributionExpiry;
 }
 ```
 
-At the time window.open() is invoked, if the associated window has a [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation), an impression event will be created and handled following [Handling an impression event](#handling-an-impression-event).
+At the time window.open() is invoked, if the associated window has a [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation), an attribution source will be created and handled following [Handling an attribution source](#handling-an-attribution-source).
 
-### Handling an impression event
+### Handling an attribution source
 
-An impression event will be logged to storage if the resulting document being
-navigated to ends up sharing the an eTLD+1 with the conversion destination of
-the impression. Concretely, this impression logs <`impressiondata`,
-`conversiondestination`, `reportingorigin`, `impressionexpiry`> to a new
+An attribution source will be logged to storage if the resulting document being
+navigated to ends up sharing the an eTLD+1 with the `attributeon` attribute of
+the attribution source. Concretely, this logs <`attributionsourcedata`,
+`attributeon`, `attributionreportto`, `attributionexpiry`> to a new
 browser storage area.
 
-When an impression is logged for <`reportingorigin`,
-`conversiondestination`>, existing impressions matching this pair will be
-looked up in storage. If the matching impressions have converted at
+When an attribution source is logged for <`attributionreportto`,
+`attributeon`>, existing sources matching this pair will be
+looked up in storage. If the matching sources have been triggered at
 least once (i.e. have scheduled a report), they will be removed from
 browser storage and will not be eligible for further reporting. Any
-pending conversion reports for these impressions will still be sent.
+pending reports for these sources will still be sent.
 
-An impression will be eligible for reporting if any page on the	
-`conversiondestination` domain (advertiser site) registers a conversion to the	
+An attribution source will be eligible for reporting if any page on the	
+`attributeon` domain (advertiser site) triggers attribution for the	
 associated reporting origin.
 
 
-### Publisher-side Controls for Impression Declaration
+### Publisher-side Controls for Source Declaration
 
-In order to prevent arbitrary third parties from registering impressions without the publisher’s knowledge, the Conversion Measurement
+In order to prevent arbitrary third parties from registering sources without the publisher’s knowledge, the Attribution Measurement
 API will need to be enabled in child contexts by a new [Feature Policy](https://w3c.github.io/webappsec-feature-policy/):
 
 ```
-<iframe src="https://advertiser.test" allow="conversion-measurement ‘src’">
+<iframe src="https://advertiser.test" allow="attribution-measurement ‘src’">
 
-<a … id="impressionTag" reportingorigin="https://ad-tech.com"></a>
+<a … id="impressionTag" attributionreportto="https://ad-tech.com"></a>
 
 </iframe>
 ```
 
-The API will be enabled by default in the top-level context and in same-origin children. Any script running in these contexts can declare an impression with any reporting origin. Publishers who wish to explicitly disable the API for all parties can do so via an [HTTP header](https://w3c.github.io/webappsec-feature-policy/#feature-policy-http-header-field).
+The API will be enabled by default in the top-level context and in same-origin children. Any script running in these contexts can declare a source with any reporting origin. Publishers who wish to explicitly disable the API for all parties can do so via an [HTTP header](https://w3c.github.io/webappsec-feature-policy/#feature-policy-http-header-field).
 
-Without a Feature Policy, a top-level document and cooperating iframe could recreate this functionality. This is possible by using [postMessage](https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage) to send impression data, reporting origin, and conversion destination to the top level document who can then wrap the iframe in an anchor tag (with some additional complexities behind handling clicks on the iframe). Using Feature Policy prevents the need for these hacks. This is inline with the classification of powerful features as discussed on [this issue](https://github.com/w3c/webappsec-feature-policy/issues/252).
+Without a Feature Policy, a top-level document and cooperating iframe could recreate this functionality. This is possible by using [postMessage](https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage) to send the attribution source data, reportto origin, and attributeon origin to the top level document who can then wrap the iframe in an anchor tag (with some additional complexities behind handling clicks on the iframe). Using Feature Policy prevents the need for these hacks. This is inline with the classification of powerful features as discussed on [this issue](https://github.com/w3c/webappsec-feature-policy/issues/252).
 
-Conversion Registration
+Triggering Attribution
 -----------------------
 
-This API will use a mechanism for conversion registration similar to the
+This API will use a mechanism for triggering attribution similar to the
 [Ad Click Attribution Proposal](https://wicg.github.io/ad-click-attribution/index.html#legacytriggering).
 
-Conversions are meant to occur on conversion destination pages. A conversion
-will be registered for a given reporting origin through an HTTP GET to
-the reporting origin, that redirects to a [.well-known](https://tools.ietf.org/html/rfc5785)
+Attribution must be triggered on an page . Attribution is
+triggered for a given `reportto` origin on a given `attributeon` through an HTTP GET to
+the origin, that redirects to a [.well-known](https://tools.ietf.org/html/rfc5785)
 location.
 This redirect is useful, because this mechanism enables the reporting origin to make server-side decisions about when attribution
 reports should trigger.
 Note that `.well-known` is only used to register a path that the browser will understand; it shouldn't point to any actual resource, since the request will be cancelled internally.
 
-Conversion registration requires the `conversion-measurement` Feature Policy to be enabled in the context the request is made. As described in [Publisher Controls for Impression Declaration](#publisher-controls-for-impression-declaration), this Feature Policy will be enabled by default in the top-level context and in same-origin children, but disabled in cross-origin children.
+Triggering attribution requires the `attribution-measurement` Feature Policy to be enabled in the context the request is made. As described in [Publisher Controls for Source Declaration](#publisher-side-controls-for-source-declaration), this Feature Policy will be enabled by default in the top-level context and in same-origin children, but disabled in cross-origin children.
 
 Today, conversion pixels are frequently used to register conversions on
-advertiser pages. These can be repurposed to register conversions in
+advertiser pages. These can be repurposed to trigger attribution in
 this API:
 
 ```
 <img src="https://ad-tech.test/conversiontracker"/>
 ```
-`https://ad-tech.test/conversiontracker` can be redirected to `https://ad-tech.test/.well-known/register-conversion`
-to trigger a conversion event.
+`https://ad-tech.test/conversiontracker` can be redirected to `https://ad-tech.test/.well-known/trigger-attribution`
+to trigger a attribution for all .
 
 The browser will treat redirects to a URL of the form:
-`https://<reportingorigin>/.well-known/register-conversion[?conversion-data=<data>]`
+`https://<attributionreportto>/.well-known/trigger-attribution[?data=<data>]`
 
-as a special request, where optional data associated with the
-conversion is specified via a query parameter.
+as a special request, where optional data associated with the event that trigged attrbution is stored in a query parameter.
 
-When the special redirect is detected, the browser will schedule a
-conversion report as detailed in [Register a conversion algorithm](#register-a-conversion-algorithm).
+When the special redirect is detected, the browser will schedule an attribution
+report as detailed in [Trigger attribution algorithm](#trigger-attribution-algorithm).
 
 ### Data limits and noise
 
-Impression data will be limited to 64 bits of information to enable
+Attribution source data will be limited to 64 bits of information to enable
 uniquely identifying an ad click.
 
-Conversion data must therefore be limited quite strictly, by limiting the amount of data and by applying noise to the data. Our strawman
-initial proposal is to allow 3 bits of conversion data, with 5%
+The advertiser-side data must therefore be limited quite strictly, by limiting the amount of data and by applying noise to the data. Our strawman
+initial proposal is to allow 3 bits of trigger data, with 5%
 noise applied — that is, with 5% chance, we send a random 3 bits, and the
-other 95% of the time we send the real conversion-data. See
-[privacy considerations](#conversion-data) for more information,
+other 95% of the time we send the real trigger data. See
+[privacy considerations](#trigger-data) for more information,
 including speculative thoughts on the hard question of going farther
-and [adding noise to whether or not the conversion report is even sent](https://github.com/csharrison/conversion-measurement-api#speculative-adding-noise-to-the-conversion-event-itself).
+and [adding noise to whether or not the attribution report is even sent](https://github.com/csharrison/conversion-measurement-api#speculative-adding-noise-to-the-attribution-report-itself).
 In any case, noise values should be allowed to vary between browsers.
 
 Disclaimer: Adding or removing a single bit of data has large
@@ -245,89 +239,87 @@ change based on community feedback. Our encoding scheme should also
 support fractions of bits, as it’s possible to limit data to values
 from 0-5 (~2.6 bits of information)
 
-### Register a conversion algorithm
+### Trigger attribution algorithm
 
-When the browser receives a conversion registration on a URL matching
-the `conversiondestination` eTLD+1, it looks up all impressions in storage that
-match <`reportingorigin`, `conversiondestination`>.
+When the browser receives a attriubtion trigger redirect on a URL matching
+the `attributeon` eTLD+1, it looks up all sources in storage that
+match <`attributionreportto`, `attributeon`>.
 
-The most recent matching impression is given an `attribution-credit` of value 100. All other matching impressions are given an `attribution-credit` of value of 0.
+The most recent matching source is given a `credit` of value 100. All other matching sources are given a `credit` of value of 0.
 
-For each matching impression, schedule a report. To schedule a report,
-the browser will store the 
- {`reportingorigin`, `conversiondestination` domain, `impressiondata`, [decoded](#data-encoding) conversion-data, attribution-credit} for the impression.
+For each matching source, schedule a report. To schedule a report,
+the browser will store
+ {`attributionreportto`, `attributeon` domain, `attributionsourcedata`, [decoded](#data-encoding) trigger-data, credit} for the source.
 Scheduled reports will be sent as detailed in [Sending scheduled reports](#sending-scheduled-reports).
 
-Each impression is only allowed to schedule a maximum of three reports
-(see [Multiple conversions for the same impression](#multiple-conversions-for-the-same-impression)). Once
-reports are scheduled for a given conversion registration, the browser
-will delete all impressions that have scheduled three reports.
+Each source is only allowed to schedule a maximum of three reports
+(see [Triggering attribution multiple times for the same source](#triggering-attribution-multiple-times-for-the-same-source)). Once
+reports are scheduled, the browser will delete all sources that have scheduled three reports.
 
-### Multiple impressions for the same conversion (Multi-touch)
+### Multiple sources for the same trigger (Multi-touch)
 
-If multiple impressions were clicked and led to a single
-conversion, send conversion reports for all of them. 
+If multiple sources were clicked and associated with a single attribution trigger, send reports for all of them. 
 
-To provide additional utility, the browser can choose to provide additional annotations to each of these reports, attributing credits for the conversion to them individually. Attribution models allow for more sophisticated, accurate conversion measurement.
+To provide additional utility, the browser can choose to provide additional annotations to each of these reports, attributing credits for the triggering refirect to them individually. Attribution models allow for more sophisticated, accurate measurement.
 
-The default attribution model will be last-click attribution, giving the last-clicked impression for a given conversion event all of the credit.
+The default attribution model will be last-click attribution, giving the last-clicked source for a given trigger redirect all of the credit.
 
-To remain flexible, the browser sends an `attribution-credit` of value 0 to 100 for all conversion reports associated with a single conversion event. This represents the percent of attribution an impression received for a conversion. The sum of credits across a set of reports for one conversion event should equal 100.
+To remain flexible, the browser sends an `credit` of value 0 to 100 for all reports associated with a single trigger. This represents the percent of attribution a source received. The sum of credits across a set of reports for one trigger should equal 100.
 
 There are many possible alternatives to this,
 like providing a choice of rules-based attribution models. However, it
 isn’t clear the benefits outweigh the additional complexity. Additionally, models other than last-click potentially leak more
-cross-site information if impressions are clicked across different
+cross-site information if sources are clicked across different
 sites.
 
-### Multiple conversions for the same impression
+### Triggering attribution multiple times for the same source
 
 Many ad clicks end up converting multiple times, for instance if a user
 goes through a checkout and a purchase flow. To support this in a
-privacy preserving way, we need to make sure that subsequent conversions
+privacy preserving way, we need to make sure that subsequent triggering a source multiple times
 do not leak too much data.
 
 One possible solution, outlined in this document, is for browsers to specify
-a maximum number of conversion registrations per click. In this document
+a maximum number of reports a single source can send. In this document
 our initial proposal is 3.
 
-Note that subsequent conversions for the same impression do not refresh
+Note that triggering attribution for the same source multiple times does not refresh
 the reporting windows (see [Sending Scheduled Reports](#sending-scheduled-reports)).
 
 Note that from a usability perspective, it is important that all
-conversion reports for the same impression are allowed the same amount
+reports for the same source are allowed the same amount
 of data. Otherwise, it becomes quite difficult for advertisers to
 efficiently use the space of possible data values.
 
 Sending Scheduled Reports
 -------------------------
 
-After the initial impression click between a publisher and advertiser, a
+After an attribution source is succesfully registered, a
 schedule of reporting windows and deadlines associated with that
-impression begins. The time between the click and impression expiry can
+source begins. The time between the click and expiry can
 be split into multiple reporting windows, at the end of which the
-browser will send scheduled reports for that impression.
+browser will send scheduled reports for that source.
 
-Each reporting window has a deadline, and only conversions registered
+Each reporting window has a deadline, and only reports created
 before that deadline can be sent in that window. An example of deadlines
 and windows a browser could choose are:
 
-2 days minus 1 hour: Conversions will be reported 2 days from impression
+2 days minus 1 hour: Reports will be sent 2 days from source registration
 time
 
-7 days minus 1 hour: Conversions will be reported 7 days from impression
+7 days minus 1 hour: Reports will be sent 7 days from source registration
 time
 
-`impressionexpiry`: Conversions will be reported `impressionexpiry`
-milliseconds plus one hour from impression time
+`attributionexpiry`: Reports will be sent `attributionexpiry`
+milliseconds plus one hour from source registration time
 
-If `impressionexpiry` occurs before the 7 day window deadline it will be used as the next reporting window. For example, if `impressionexpiry` is 3 days, there will be two deadlines, 2 days minus one hour and `impressionexpiry`. If `impressionexpiry` is before the 2 day deadline, the 2 day deadline will still be used. 
+If `attributionexpiry` occurs before the 7 day window deadline it will be used as the next reporting window. For example, if `attributionexpiry` is 3 days, there will be two deadlines, 2 days minus one hour and `attributionexpiry`. If `attributionexpiry` is before the 2 day deadline, the 2 day deadline will still be used. 
 
-When a conversion report is scheduled, it will be delayed until the next
-applicable reporting window for the associated impression. Once the
+When a report is scheduled, it will be delayed until the next
+applicable reporting window for the associated source. Once the
 window has finished, the report will be sent out of band.
 
-If there are multiple reports for an impression scheduled within the
+If there are multiple reports for a source scheduled within the
 same window, the reports will be sent at the same time but in a random
 order.
 
@@ -340,23 +332,22 @@ easily by a given reporting origin.
 Note that to improve utility, it might be possible to randomly send
 reports throughout each reporting window.
 
-### Conversion Reports
+### Attribution Reports
 
 To send a report, the browser will make a non-credentialed (i.e. without session cookies) secure
 HTTP POST request to:
 
 ```
-https://reportingorigin/.well-known/register-conversion?impression-data=&conversion-data=&attribution-credit=
+https://attributionreportto/.well-known/report-attribution
 ```
 
-The conversion report data is included as query params as they represent
-non-hierarchical data ([URI RFC](https://tools.ietf.org/html/rfc3986#section-3.4)):
+The report data is included in the request body as a JSON object with the following keys:
 
--   `impression-data`: 64 bit data set on the impression
+-   `sourceData`: 64 bit data set on the attribution source
 
--   `conversion-data`: 3 bit data set in the conversion redirect
+-   `triggerData`: 3 bit data set in the attribution trigger redirect
 
--   `attribution-credit`: integer in range [0, 100], denotes the percentage of credit this impression received for the given conversion. If a conversion only had one matching impression, this will be 100.
+-   `credit`: integer in range [0, 100], denotes the percentage of credit this source received for the given trigger. If a trigger only had one matching source, this will be 100.
 
 The advertiser site’s eTLD+1 will be added as the Referrer. Note that it
 might be useful to advertise which data limits were used in the
@@ -369,7 +360,7 @@ API in the future should it be desirable.
 Data Encoding
 -----------------
 
-Impression data and conversion data should be encoded the same
+Attribution source data and trigger data should be encoded the same
 way, and in a way that is amenable to any privacy level a browser would
 want to choose (i.e. the number of distinct data states supported).
 
@@ -396,79 +387,87 @@ cross-origin iframe to host the third party advertisement for
 `toasters.com`, and sets `ad-tech.com` to be an allowed reporting origin.
 
 Within the iframe, `toasters.com` code annotates their anchor tags to use
-the `ad-tech.com` reporting origin, and uses impression data that allows
+the `ad-tech.com` reporting origin, and uses a source data value that allows
 `ad-tech.com` to identify the ad click (12345678)
 ```
-<iframe src="https://ad-tech-3p.test/show-some-ad" allow="conversion-reporting ‘src’ (https://ad-tech.com)">
+<iframe src="https://ad-tech-3p.test/show-some-ad" allow="attribution-measurement ‘src’ (https://ad-tech.com)">
 ...
 <a 
   href="https://toasters.com/purchase"
-  conversiondestination="https://toasters.com"
-  impressiondata="12345678"
-  reportingorigin="https://ad-tech.com"
-  impressionexpiry=604800000>
+  attributeon="https://toasters.com"
+  attributionsourcedata="12345678"
+  attributionreportto="https://ad-tech.com"
+  attributionexpiry=604800000>
 ...
 </iframe>
 ```
 
 A user clicks on the ad and this opens a window that lands on a URL to
-`toasters.com/purchase`. An impression event is logged to browser storage
-since the landing page matches the conversion destination. The following data is
+`toasters.com/purchase`. An attribution source is logged to browser storage
+since the landing page matches the `attributeon` etld+1. The following data is
 stored:
 
 ```
 {
-  impression-data: 12345678,
-  conversion-destination: https://toasters.com,
-  reporting-origin: https://ad-tech.com,
-  impression-expiry: <now() + 604800>
+  attributionsourcedata: 12345678,
+  attributeon: https://toasters.com,
+  attributionreportto: https://ad-tech.com,
+  attributionexpiry: <now() + 604800>
 }
 ```
 
 2 days later, the user buys something on `toasters.com`. `toasters.com`
-registers conversions on the few different ad-tech companies it buys
-impressions on, including `ad-tech.com`, by adding conversion pixels:
+triggers attribution on the few different ad-tech companies it buys
+ads on, including `ad-tech.com`, by adding conversion pixels:
 
 ```
-<img src="https://ad-tech.com/conversion?model=toastmaster3000&price=$49.99&..." />
+<img src="https://ad-tech.com/trigger-attribution?model=toastmaster3000&price=$49.99&..." />
 ```
 
-`ad-tech.com` receives this request, and decides to trigger a conversion
-on `toasters.com`. They must compress all of the conversion data into
+`ad-tech.com` receives this request, and decides to trigger attribution
+on `toasters.com`. They must compress all of the data into
 3 bits, so `ad-tech.com` chooses to encode the value as “2" (e.g. some
 bucketed version of the purchase value). They respond with a 302
 redirect to:
 ```
-https://ad-tech.com/.well-known/register-conversion?conversion-data=2
+https://ad-tech.com/.well-known/trigger-attribution?data=2
 ```
 
-The browser sees this request, and schedules a conversion report to be
-sent. The conversion report is associated with the 7 day deadline as the
+The browser sees this request, and schedules a report to be
+sent. The report is associated with the 7 day deadline as the
 2 day deadline has passed. Roughly 5 days later, `ad-tech.com` receives
 the following HTTP POST:
 ```
-https://ad-tech.com/.well-known/register-conversion?impression-data=12345678&conversion-data=2&attribution-credit=100
+URL:
+https://ad-tech.com/.well-known/report-attribution
+
+body:
+{
+  "sourceData": "12345678",
+  "triggerData": "2",
+  "creidt": 100
+}
 ```
 
 Privacy Considerations
 ======================
 The main privacy goal of the API is to make _linking identity_ between two different top-level sites difficult. This happens when either a request or a Javascript environment has two user IDs from two different sites simultaneously.
 
-In this API, the 64-bit impression ID can encode a user ID from the publisher’s top level site, but the low entropy, noisy conversion data could only encode a small part of a user ID from the advertiser’s top-level site. The impression ID and the conversion data are never exposed to a Javascript environment together, and the request that includes both of them is sent without credentials and at a different time from either event, so the request adds little new information linkable to these events.
+In this API, the 64-bit source ID can encode a user ID from the publisher’s top level site, but the low entropy, noisy trigger data could only encode a small part of a user ID from the advertiser’s top-level site. The source ID and the trigger data are never exposed to a Javascript environment together, and the request that includes both of them is sent without credentials and at a different time from either event, so the request adds little new information linkable to these events.
 
 While this API _does_ allow you to learn "which ad clicks converted", it isn’t enough to link the user's identity on the publisher's and advertiser's side, unless there is serious abuse of the API, i.e. abusers are using error correcting codes and many clicks to slowly and probabilistically learn advertiser IDs associated with publisher ones. We explore some mitigations to this attack below.
 
 
-Conversion Data
+Trigger Data
 -------------------
 
-Conversion data is extremely important for critical use cases like
-reporting the *purchase value* of a conversion. However, too much conversion
+Trigger data, e.g. advertiser side data, is extremely important for critical use cases like
+reporting the *purchase value* of a conversion. However, too much advertiser-side
 data could be used to link advertiser identity with publisher
 identity.
 
 Mitigations against this are to provide only coarse information (only a
-few bits at a time), and introduce some noise to the conversion. Even
+few bits at a time), and introduce some noise to the trigger-data. Even
 sophisticated attackers will therefore need to invoke the API many times
 (through many clicks) to join identity between sites with high
 confidence.
@@ -478,33 +477,33 @@ with an unbiased estimator. See generic approaches of dealing with
 [Randomized response](https://en.wikipedia.org/wiki/Randomized_response) for
 a starting point.
 
-Conversion Delay 
+Reporting Delay 
 -----------------
 
 By bucketing reports within a small number reporting deadlines, it
-becomes harder to associate a conversion report with the identity of the
+becomes harder to associate a report with the identity of the
 user on the advertiser’s site via timing side channels.
 
-Conversions within the same reporting window occur within an anonymity
+Reprots within the same reporting window occur within an anonymity
 set with all others during that time period. For example, if we didn’t
-bucket conversion reports, the reports (which contain publisher ids)
+bucket reports, the reports (which contain publisher ids)
 could be easily joined up with the advertiser’s first party information
 via correlating timestamps.
 
 Note that the delay windows / deadlines chosen represent a trade-off
 with utility, since it becomes harder to properly assign credit to a
 click if the time from click to conversion is not known. That is,
-time-to-conversion is an important signal for proper conversion
+time-to-conversion is an important signal for proper
 attribution. Browsers should make sure that this trade-off is concretely
 evaluated for both privacy and utility before deciding on a delay.
 
-Limits on the number of conversion pixels
+Limits on the number of attribution triggers
 -----------------------------------------
 
-If the advertiser is allowed to cycle through many possible reporting
+If the advertiser is allowed to cycle through many possible `reportto`
 origins (via injecting many `<img>` tags on the page), then the
 publisher and advertiser don’t necessarily have to agree apriori on what
-reporting origin to use, and which origin actually ends up getting used
+origin to use, and which origin actually ends up getting used
 reveals some extra information.
 
 To prevent abuse, it makes sense for browsers to add limits here, potentially
@@ -513,7 +512,7 @@ on a per-page load or per-reporting epoch basis.
 Clearing Site Data
 ------------------
 
-Impressions / conversions in browser storage should be clearable using
+Attribution sources / reports in browser storage should be clearable using
 existing “clear browsing data" functionality offered by browsers.
 
 Reporting cooldown
@@ -522,9 +521,9 @@ Reporting cooldown
 To limit the amount of user identity leakage between a <publisher,
 advertiser> pair, the browser should throttle the amount of total
 information sent through this API in a given time period for a user. The
-browser should set a maximum number of conversion reports per
+browser should set a maximum number of attribution reports per
 <publisher, advertiser, user> tuple per time period. If this
-threshold is hit, the browser will disable the conversion API for the
+threshold is hit, the browser will disable the API for the
 rest of the time period for that user.
 
 The longer the cooldown windows are, the harder it is to abuse the API
@@ -538,7 +537,7 @@ Speculative: Limits based on first party storage
 ------------------------------------------------
 
 Another mitigation on joining identity across publisher and advertiser
-sites is to limit the number of conversion reports for any given
+sites is to limit the number of reports for any given
 <publisher, advertiser> pair until the advertiser clears their
 site data. This could occur via the [Clear-Site-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data)
 header or by explicit user action.
@@ -547,37 +546,37 @@ To prevent linking across deletions, we might need to introduce new
 options to the Clear-Site-Data header to only clear data after the page
 has unloaded.
 
-Speculative: Adding noise to the conversion event itself
+Speculative: Adding noise to the attribution of the source itself
 --------------------------------------------------------
 
 Another way to add privacy to this system is to add noise not only to
-the [reported conversion data value](#data-limits-and-noise),
-but also to whether the conversion occurred in the first place. That is:
+the [reported trigger data value](#data-limits-and-noise),
+but also to whether attribution was triggered in the first place. That is:
 
--   With some probability *p*, true conversions will be dropped
+-   With some probability *p*, sources that are triggered will be dropped
 
--   With some probability *q*, impressions that have not converted will be marked as converted, and given random conversion data.
+-   With some probability *q*, sources that have not been triggered will be triggered, and given random `trigger-data`.
 
-The biggest problem with this scheme is that conversion events are, in
+The biggest problem with this scheme is that triggering attribution sources, in
 general, *rare*. Additionally, different advertisers can have wildly
-different *conversion rates*. These two facts make it very hard to pick
+different *attribution rates*. These two facts make it very hard to pick
 a *q* that works reliably without drowning out the signal with noise.
 We’re still thinking of solutions here.
 
-Additionally, sending conversion reports for impressions that never
+Additionally, sending reports for sources that never
 actually converted could have real monetary impact on advertisers that
-pay per conversion. Tight bounds on error estimation will be crucial for
+pay per attributed source. Tight bounds on error estimation will be crucial for
 correct billing in these cases.
 
 Open Questions
 ==============
 
-Multiple Reporting Endpoints Per Conversion
+Multiple Reporting Endpoints Per Attributed Source
 -------------------------------------------
 
 An advertiser may want to send reports to multiple reporting partners at
-the same time. This is very tricky to get right without revealing any
-extra information. Allowing different conversion data for different
+the same time for the same attributed source. This is very tricky to get right without revealing any
+extra information. Allowing different trigger data for different
 reporting endpoints makes things even more difficult.
 
 This problem becomes a bit easier if reporting partners mutually trust

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ https://attributionreportto/.well-known/report-attribution
 
 The report data is included in the request body as a JSON object with the following keys:
 
--   `source_data`: 64 bit data set on the attribution source
+-   `source_event_id`: 64 bit event id set on the attribution source
 
 -   `trigger_data`: 3 bit data set in the attribution trigger redirect
 
@@ -437,8 +437,8 @@ https://ad-tech.com/.well-known/report-attribution
 
 body:
 {
-  "sourceData": "12345678",
-  "triggerData": "2",
+  "source_event_id": "12345678",
+  "trigger_data": "2",
   "credit": 100
 }
 ```

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ noise applied — that is, with 5% chance, we send a random 3 bits, and the
 other 95% of the time we send the real trigger data. See
 [privacy considerations](#trigger-data) for more information,
 including speculative thoughts on the hard question of going farther
-and [adding noise to whether or not the attribution report is even sent](https://github.com/csharrison/conversion-measurement-api#speculative-adding-noise-to-the-attribution-report-itself).
+and [adding noise to whether or not the attribution report is even sent](#speculative-adding-noise-to-the-attribution-of-the-source-itself).
 In any case, noise values should be allowed to vary between browsers.
 
 Disclaimer: Adding or removing a single bit of data has large


### PR DESCRIPTION
This updates the proposed API with the naming changes discussed on #57.

This includes updating the reporting format to a JSON body with the new names