### PR TITLE
Change "attributeon" naming to "attributiondestination"

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The most recent matching source is given a `credit` of value 100. All other matc
 
 For each matching source, schedule a report. To schedule a report,
 the browser will store
- {`attributionreportto`, `attributiondestination` domain, `attributionsourceeventid`, [decoded](#data-encoding) trigger-data, credit} for the source.
+ {`attributionreportto`, `attributiondestination` eTLD+1, `attributionsourceeventid`, [decoded](#data-encoding) trigger-data, credit} for the source.
 Scheduled reports will be sent as detailed in [Sending scheduled reports](#sending-scheduled-reports).
 
 Each source is only allowed to schedule a maximum of three reports


### PR DESCRIPTION
This updates the explainer with new naming as discussed on https://github.com/privacycg/private-click-measurement/pull/75#discussion_r593476675