### PR TITLE
Use straight quotes inside of allow attribute value

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ associated reporting origin.
 In order to prevent arbitrary third parties from registering sources without the publisher’s knowledge, the Attribution Reporting API will need to be enabled in child contexts by a new [Feature Policy](https://w3c.github.io/webappsec-feature-policy/):
 
 ```
-<iframe src="https://advertiser.test" allow="attribution-reporting ‘src’">
+<iframe src="https://advertiser.test" allow="attribution-reporting 'src'">
 
 <a … id="..." attributionreportto="https://ad-tech.com"></a>
 


### PR DESCRIPTION
This is currently written using left and right quotes, which aren't handled by the Permissions Policy spec given the definition of the 'src' keyword, https://w3c.github.io/webappsec-permissions-policy/#allowlists