### PR TITLE
Rename document.attribution to attributionReporting

### DIFF
--- a/event_attribution_reporting.md
+++ b/event_attribution_reporting.md
@@ -34,7 +34,7 @@ Scripts running on a source site can register attribution sources via a new Java
 The browser will expose a new interface:
 
 ```
-[Exposed=Window] interface Attribution {
+[Exposed=Window] interface AttributionReporting {
   bool registerAttributionSource(AttributionSourceParams params);
 }
 ```


### PR DESCRIPTION
"Attribution" is a fairly generic term. It seems more ideal to have the proposed window exposed interface match the API name to the extent possible.