### PR TITLE
Update attributionsourceeventid encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ Attribution Source Declaration
 
 An attribution source is an anchor tag with special attributes:
 
-`<a attributiondestination="[eTLD+1]" attributionsourceeventid=[unsigned long long]
+`<a attributiondestination="[eTLD+1]" attributionsourceeventid="[64-bit unsigned integer]"
 attributionexpiry=[unsigned long long] attributionreportto="[origin]">`
 
 Attribution source attributes:
 
 -   `attributiondestination`: an origin whose eTLD+1 is where attribution will be triggered for this source. 
 
--   `attributionsourceeventid`: the event-level data associated with this source. This will be limited to 64 bits of information but the value can vary for browsers that want a higher level of privacy.
+-   `attributionsourceeventid`: A DOMString representing a 64-bit unsigned integer which represents the event-level data associated with this source. This will be limited to 64 bits of information but the value can vary for browsers that want a higher level of privacy.
 
 -   `attributionexpiry`: (optional) expiry in milliseconds for when the source should be deleted. Default is 30 days, with a maximum value of 30 days. The maximum expiry can also vary between browsers.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Attribution source attributes:
 
 -   `attributiondestination`: an origin whose eTLD+1 is where attribution will be triggered for this source. 
 
--   `attributionsourceeventid`: A DOMString representing a 64-bit unsigned integer which represents the event-level data associated with this source. This will be limited to 64 bits of information but the value can vary for browsers that want a higher level of privacy.
+-   `attributionsourceeventid`: A DOMString encoding a 64-bit unsigned integer which represents the event-level data associated with this source. This will be limited to 64 bits of information but the value can vary for browsers that want a higher level of privacy.
 
 -   `attributionexpiry`: (optional) expiry in milliseconds for when the source should be deleted. Default is 30 days, with a maximum value of 30 days. The maximum expiry can also vary between browsers.
 

--- a/app_to_web.md
+++ b/app_to_web.md
@@ -33,7 +33,7 @@ See [explainer](https://github.com/WICG/conversion-measurement-api/blob/main/REA
 <!-- Click-through attributions: -->
 <a 
   href="https://advertiser.example/buy-shoes"
-  attributionsourceeventid=123456
+  attributionsourceeventid="123456"
   attributionreportto="https://reporter.example"
   attributeon="https://advertiser.example"
   attributionexpiry=604800000>
@@ -58,7 +58,7 @@ To register clicks from apps, we can send an ACTION_VIEW Intent with some extra 
 // TODO: which namespace should the APP_ATTRIBUTION type live in?
 Intent convIntent = new Intent("android.web.action.APP_ATTRIBUTION");
 Bundle innerBundle = new Bundle();
-innerBundle.putInt("attributionSourceEventId", 123456);
+innerBundle.putString("attributionSourceEventId", "123456");
 innerBundle.putString("attributionReportTo", "https://reporter.example");
 innerBundle.putString("attributeOn", "https://advertiser.example");
 innerBundle.putInt("attributionExpiry", 604800000);
@@ -100,7 +100,7 @@ Views won't necessarily start the browser with an intent, so we can use a [Conte
 ```java
 // After an ad view. Parameters for event-level API only.
 ContentValues newValues = new ContentValues();
-newValues.put("attributionSourceEventId", 123456);
+newValues.put("attributionSourceEventId", "123456");
 newValues.put("attributionReportTo", "https://reporter.example");
 newValues.put("attributeOn", "https://advertiser.example");
 newValues.put("attributionExpiry", 604800000);


### PR DESCRIPTION
Updates the README and app to web explainer to have attributionsourceeventid be encoded as a string, as suggested on #123