### PR TITLE
Update window.open interface to use features parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Clicking on an anchor tag that specifies these attributes will create a new attr
 
 An attribution source can be registered for navigations initiated by [`window.open()`](https://html.spec.whatwg.org/multipage/window-object.html#dom-open).
 
-A source is registered through a `window.open()` by providing attribution source attributes within the `features` parameter:
+A source is registered in a call to `window.open()` by providing attribution source attributes within the `features` parameter:
 
 ```
 window.open("https://dest.example", "_blank",     

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ A source is registered in a call to `window.open()` by providing attribution sou
 
 ```
 window.open("https://dest.example", "_blank",     
- "noopener,attributionsourceeventid=1234,attributiondestination=https://dest.example,attributionreportto=https://reporter.example,attributionexpiry=604800000");)
+ "noopener,attributionsourceeventid=1234,attributiondestination=https://dest.example,\
+ attributionreportto=https://reporter.example,attributionexpiry=604800000");)
 ```
 
 At the time window.open() is invoked with these attributes specified in `features`, if the associated window has a [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation), an attribution source event will be created and handled following [Handling an attribution source event](#handling-an-attribution-source-event).

--- a/README.md
+++ b/README.md
@@ -120,28 +120,14 @@ Clicking on an anchor tag that specifies these attributes will create a new attr
 
 An attribution source can be registered for navigations initiated by [`window.open()`](https://html.spec.whatwg.org/multipage/window-object.html#dom-open).
 
-A source is registered through a new `window.open()` overload:
+A source is registered through a `window.open()` by providing attribution source attributes within the `features` parameter:
 
 ```
-WindowProxy? open(
-  optional USVString url = "",
-  optional DOMString target = "_blank",
-  optional [LegacyNullToEmptyString] DOMString features = "",
-  optional AttributionSourceParams attribution_source_params)
+window.open("https://dest.example", "_blank",     
+ "noopener,attributionsourceeventid=1234,attributiondestination=https://dest.example,attributionreportto=https://reporter.example,attributionexpiry=604800000");)
 ```
 
-`AttributionSourceParams` is a dictionary which contains the same attributes used by attribution source anchor tags:
-
-```
-dictionary AttributionSourceParams {
-  required DOMString attributionSourceEventId;
-  required USVString attributionDestination;
-  optional USVString attributionReportTo;
-  optional unsigned long attributionExpiry;
-}
-```
-
-At the time window.open() is invoked, if the associated window has a [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation), an attribution source event will be created and handled following [Handling an attribution source event](#handling-an-attribution-source-event).
+At the time window.open() is invoked with these attributes specified in `features`, if the associated window has a [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation), an attribution source event will be created and handled following [Handling an attribution source event](#handling-an-attribution-source-event).
 
 ### Handling an attribution source event
 

--- a/event_attribution_reporting.md
+++ b/event_attribution_reporting.md
@@ -39,7 +39,18 @@ The browser will expose a new interface:
 }
 ```
 
-See [this section](https://github.com/WICG/conversion-measurement-api/blob/main/README.md#registering-attribution-sources-for-windowopen-navigations) of the Attribution Reporting explainer for the definition of `AttributionSourceParams`. When invoked the browser will directly add the specified source to storage, and return whether the browser was successful in parsing the params.
+`AttributionSourceParams` is a dictionary which contains the same attributes used by attribution source anchor tags:
+
+```
+dictionary AttributionSourceParams {
+  required DOMString attributionSourceEventId;
+  required USVString attributionDestination;
+  optional USVString attributionReportTo;
+  optional unsigned long attributionExpiry;
+}
+```
+
+When invoked the browser will directly add the specified source to storage, and return whether the browser was successful in parsing the params.
 
 
 ### Different Classes of Attribution Sources


### PR DESCRIPTION
This updates the window.open overload to supply attribution reporting attributes in the features parameter, rather than in a new window.open overload per #130