### PR TITLE
Update <a> element monkey patch with content attributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -49,6 +49,28 @@ conversion domain.
 
 # HTML monkeypatches # {#html-monkeypatches}
 
+<h3 id="longlong-reflection"> long long reflection </h3>
+
+Add the following rules for <a spec=html>reflecting</a> <a spec=html>content attributes</a>:
+
+If a reflecting IDL attribute has a signed integer type ({{long long}}) then, on getting, the content attribute must be
+parsed according to the <a spec="html">rules for parsing integers</a>, and if that is successful, and the value is in the
+range of the IDL attribute's type, the resulting value must be returned. If, on the other hand, it fails or returns
+an out of range value, or if the attribute is absent, then the default value must be returned instead, or 0 if there
+is no default value. On setting, the given value must be converted to the shortest possible string representing the
+number as a valid integer and then that string must be used as the new content attribute value.
+
+If a reflecting IDL attribute has a signed integer type ({{long long}}) that is <dfn>limited to only non-negative numbers</dfn> then,
+on getting, the content attribute must be parsed according to the <a spec="html">rules for parsing non-negative integers</a>, and if
+that is successful, and the value is in the range of the IDL attribute's type, the resulting value must be returned.
+If, on the other hand, it fails or returns an out of range value, or if the attribute is absent, the default value
+must be returned instead, or −1 if there is no default value. On setting, if the value is negative, the user agent
+must throw an {{"IndexSizeError"}} {{DOMException}}. Otherwise, the given value must be converted to the shortest possible
+string representing the number as a valid non-negative integer and then that string must be used as the new content
+attribute value.
+
+<h3 id="monkeypatch-anchor">&lt;a&gt; element</h3>
+
 Add the following <a spec=html>content attributes</a> to the <{a}> element:
 
 : <{a/attributionsourceeventid}>
@@ -72,8 +94,11 @@ partial interface HTMLAnchorElement {
 </pre>
 
 The IDL attributes {{HTMLAnchorElement/attributionDestination}}, {{HTMLAnchorElement/attributionSourceEventId}}, 
-{{HTMLAnchorElement/attributionReportTo}}, {{HTMLAnchorElement/attributionExpiry}}
-must <a spec=html>reflect</a> the respective content attributes of the same name.
+{{HTMLAnchorElement/attributionReportTo}} must <a spec=html>reflect</a> the respective content 
+attributes of the same name.
+
+The IDL attribute {{HTMLAnchorElement/attributionExpiry}} must reflect the <{a/attributionexpiry}>
+content attribute, [=limited to only non-negative numbers=].
 
 The <dfn for="a" element-attr>attributiondestination</dfn> attribute is a string
 representing an [=url/origin=] that is intended to be [=same site=] with the origin

--- a/index.bs
+++ b/index.bs
@@ -64,15 +64,15 @@ Extend the <{a}> element's <a spec=html>DOM interface</a> to include the followi
 
 <pre class="idl">
 partial interface HTMLAnchorElement {
-    [CEReactions] attribute DOMString attributiondestination;
-    [CEReactions] attribute DOMString attributionsourceeventid;
-    [CEReactions] attribute DOMString attributionreportto;
-    [CEReactions] attribute DOMString attributionexpiry;
+    [CEReactions] attribute DOMString attributionDestination;
+    [CEReactions] attribute DOMString attributionSourceEventId;
+    [CEReactions] attribute DOMString attributionReportTo;
+    [CEReactions] attribute long long attributionExpiry;
 };
 </pre>
 
-The IDL attributes {{HTMLAnchorElement/attributiondestination}}, {{HTMLAnchorElement/attributionsourceeventid}}, 
-{{HTMLAnchorElement/attributionreportto}}, {{HTMLAnchorElement/attributionexpiry}}
+The IDL attributes {{HTMLAnchorElement/attributionDestination}}, {{HTMLAnchorElement/attributionSourceEventId}}, 
+{{HTMLAnchorElement/attributionReportTo}}, {{HTMLAnchorElement/attributionExpiry}}
 must <a spec=html>reflect</a> the respective content attributes of the same name.
 
 The <dfn for="a" element-attr>attributiondestination</dfn> attribute is a string

--- a/index.bs
+++ b/index.bs
@@ -49,29 +49,45 @@ conversion domain.
 
 # HTML monkeypatches # {#html-monkeypatches}
 
-Add the following content attributes to the <{a}> element:
+Add the following <a spec=html>content attributes</a> to the <{a}> element:
+
+: <{a/attributionsourceeventid}>
+:: Identifies the declared attribution source
+: <{a/attributiondestination}>
+:: Site which can attribute an event to the declared attribution source
+: <{a/attributionreportto}>
+:: [=url/origin=] to receive attribution reports
+: <{a/attributionexpiry}>
+:: Length of time the attribution souce is valid
+
+Extend <{a}> element <a spec=html>DOM interface</a> to include the following interface:
 
 <pre class="idl">
 partial interface HTMLAnchorElement {
-    [CEReactions, Reflect] attribute DOMString attributiondestination;
-    [CEReactions, Reflect] attribute DOMString attributionsourceeventid;
-    [CEReactions, Reflect] attribute DOMString attributionreportto;
-    [CEReactions, Reflect] attribute unsigned long long attributionexpiry;
+    [CEReactions] attribute DOMString attributiondestination;
+    [CEReactions] attribute DOMString attributionsourceeventid;
+    [CEReactions] attribute DOMString attributionreportto;
+    [CEReactions] attribute DOMString attributionexpiry;
 };
 </pre>
 
-The <dfn for="a" element-attr>attributiondestination</dfn> is an [=url/origin=]
-that is intended to be [=same site=] with the origin of the final navigation url resulting 
-from running <a spec="html">follow the hyperlink</a> with the <{a}> element.
+The IDL attributes {{HTMLAnchorElement/attributiondestination}}, {{HTMLAnchorElement/attributionsourceeventid}}, 
+{{HTMLAnchorElement/attributionreportto}}, {{HTMLAnchorElement/attributionexpiry}}
+must <a spec=html>reflect</a> the respective content attributes of the same name.
 
-The <dfn for="a" element-attr>attributionsourceeventid</dfn> is a string
+The <dfn for="a" element-attr>attributiondestination</dfn> attribute is a string
+representing an [=url/origin=] that is intended to be [=same site=] with the origin
+of the final navigation url resulting from running <a spec="html">follow the hyperlink</a>
+with the <{a}> element.
+
+The <dfn for="a" element-attr>attributionsourceeventid</dfn> attribute is a string
 containing information about the `attribution source` and will be supplied in the
 [=attribution report=].
 
-The <dfn for="a" element-attr>attributionreportto</dfn> optionally declares the
+The <dfn for="a" element-attr>attributionreportto</dfn> attribute optionally declares the
 [=origin=] to send the [=attribution report=] for this source.
 
-The <dfn for="a" element-attr>attributionexpiry</dfn> optionally defines the amount
+The <dfn for="a" element-attr>attributionexpiry</dfn> attribute optionally defines the amount
 of time in milliseconds the attribution source should be considered for reporting.
 
 Issue: Need monkey patches passing attribution source in navigation, and a mechanism

--- a/index.bs
+++ b/index.bs
@@ -60,7 +60,7 @@ Add the following <a spec=html>content attributes</a> to the <{a}> element:
 : <{a/attributionexpiry}>
 :: Length of time the attribution souce is valid
 
-Extend <{a}> element <a spec=html>DOM interface</a> to include the following interface:
+Extend the <{a}> element's <a spec=html>DOM interface</a> to include the following interface:
 
 <pre class="idl">
 partial interface HTMLAnchorElement {


### PR DESCRIPTION
Includes the list of content attributes to add, and specifies that they must be reflected from the idl attributes as discussed on #133


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/pull/140.html" title="Last updated on May 19, 2021, 5:26 PM UTC (079db6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/140/5c456e6...079db6f.html" title="Last updated on May 19, 2021, 5:26 PM UTC (079db6f)">Diff</a>