### PR TITLE
Revert "Spec storage for attribution sources and reports"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -129,19 +129,6 @@ An attribution report is a [=struct=] with the following items:
 
 </dl>
 
-# Storage # {#storage}
-
-A user agent MUST provide access to a set of <dfn>attribution caches</dfn> which are shared among all
-[=environment settings objects=] and consist of:
-
-1. an <dfn>attribution source cache</dfn>, which is an [=ordered set=] of [=attribution sources=].
-1. an <dfn>attribution report cache</dfn>, which is an [=ordered set=] of [=attribution reports=].
-
-User agents SHOULD place limits on the maximum [=list/size=] of the [=attribution caches=].
-
-Issue: This would ideally use <a spec=storage>storage bottles</a> to provide access to the attribution caches.
-However attribution data is inherently cross-site, and operations on storage would need to span across all storage bottle maps.
-
 # Algorithms # {#algorithms}
 
 <h3 algorithm id="parsing-attribution-destination">Parsing an attribution destination</h3>
@@ -293,8 +280,3 @@ TODO
 
 # Privacy consideration # {#privacy-considerations}
 TODO
-
-<h3 id="clearing-attribution-storage">Clearing attribution storage</h3>
-
-A user agent's [=attribution caches=] contain data about a user's web activity. If a user agent gives users the ability to clear 
-their browsing history and browsing related storage, the user agent MUST also remove the related items within the [=attribution caches=].


### PR DESCRIPTION
Reverts WICG/conversion-measurement-api#141, this was merged accidentally instead of #140


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/pull/151.html" title="Last updated on May 25, 2021, 6:18 PM UTC (2bfb433)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/151/98dbdac...2bfb433.html" title="Last updated on May 25, 2021, 6:18 PM UTC (2bfb433)">Diff</a>