### PR TITLE
Spec declaration of attributionsourcepriority

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -82,7 +82,7 @@ Add the following <a spec=html>content attributes</a> to the <{a}> element:
 : <{a/attributionexpiry}>
 :: Length of time the attribution souce is valid
 : <{a/attributionsourcepriority}>
-:: The priority of this source relative to other sources for attribution triggers
+:: The priority of this source relative to other sources when triggering attribution
 
 Extend the <{a}> element's <a spec=html>DOM interface</a> to include the following interface:
 

--- a/index.bs
+++ b/index.bs
@@ -81,6 +81,8 @@ Add the following <a spec=html>content attributes</a> to the <{a}> element:
 :: [=url/origin=] to receive attribution reports
 : <{a/attributionexpiry}>
 :: Length of time the attribution souce is valid
+: <{a/attributionsourcepriority}>
+:: The priority of this source relative to other sources for attribution triggers
 
 Extend the <{a}> element's <a spec=html>DOM interface</a> to include the following interface:
 
@@ -90,6 +92,7 @@ partial interface HTMLAnchorElement {
     [CEReactions] attribute DOMString attributionSourceEventId;
     [CEReactions] attribute DOMString attributionReportTo;
     [CEReactions] attribute long long attributionExpiry;
+    [CEReactions] attribute long long attributionSourcePriority;
 };
 </pre>
 
@@ -114,6 +117,9 @@ The <dfn for="a" element-attr>attributionreportto</dfn> attribute optionally dec
 
 The <dfn for="a" element-attr>attributionexpiry</dfn> attribute optionally defines the amount
 of time in milliseconds the attribution source should be considered for reporting.
+
+The <dfn for="a" element-attr>attributionsourcepriority</dfn> attribute optionally defines the
+priority of a source relative to other sources when triggering attribution.
 
 <h3 id="monkeypatch-navigation">Navigation</h3>
 
@@ -241,6 +247,8 @@ An attribution source is a [=struct=] with the following items:
 :: An [=url/origin=].
 : <dfn>expiry</dfn>
 :: A point in time.
+: <dfn>priority</dfn>
+:: A 64-bit integer.
 : <dfn>source time</dfn>
 :: A point in time.
 : <dfn>number of reports</dfn>
@@ -322,7 +330,11 @@ To <dfn>obtain an attribution source</dfn> from an <{a}> element |anchor|:
 1. Let |expiry| be 30 days.
 1. If |anchor| has an <{a/attributionexpiry}> attribute, and applying the
     <a spec="html">rules for parsing non-negative integers</a> to the attributes's value
-    results in a number greater than zero, then set |expiry| to that value.
+    results in an integer greater than zero, then set |expiry| to that value.
+1. Let |priority| be 0.
+1. If |anchor| has an <{a/attributionsourcepriority}> attribute, and applying the
+    <a spec="html">rules for parsing integers</a> to the attributes's value
+    results in an integer, then set |priority| to that value.
 1. Let |source| be a new [=attribution source=] struct whose items are:
 
     : [=attribution source/source origin=]
@@ -336,6 +348,8 @@ To <dfn>obtain an attribution source</dfn> from an <{a}> element |anchor|:
     :: |reportingOrigin|
     : [=attribution source/expiry=]
     :: |currentTime| + |expiry|
+    : [=attribution source/priority=]
+    :: |priority|
     : [=attribution source/source time=]
     :: |currentTime|
 1. Return |source|

--- a/index.bs
+++ b/index.bs
@@ -97,8 +97,8 @@ partial interface HTMLAnchorElement {
 </pre>
 
 The IDL attributes {{HTMLAnchorElement/attributionDestination}}, {{HTMLAnchorElement/attributionSourceEventId}}, 
-{{HTMLAnchorElement/attributionReportTo}} must <a spec=html>reflect</a> the respective content 
-attributes of the same name.
+{{HTMLAnchorElement/attributionReportTo}}, {{HTMLAnchorElement/attributionSourcePriority}} must <a spec=html>reflect</a> 
+the respective content attributes of the same name.
 
 The IDL attribute {{HTMLAnchorElement/attributionExpiry}} must reflect the <{a/attributionexpiry}>
 content attribute, [=limited to only non-negative numbers=].

--- a/index.bs
+++ b/index.bs
@@ -119,7 +119,12 @@ The <dfn for="a" element-attr>attributionexpiry</dfn> attribute optionally defin
 of time in milliseconds the attribution source should be considered for reporting.
 
 The <dfn for="a" element-attr>attributionsourcepriority</dfn> attribute optionally defines the
-priority of a source relative to other sources when triggering attribution.
+priority of a source relative to other sources when triggering attribution. If not specified, 0 is used as the
+priority. An [=attribution trigger=] with a given [=attribution trigger/reporting endpoint=] and [=attribution trigger/trigger origin=]
+will always be attributed to the source with the highest priority value that has the same [=attribution source/reporting endpoint=] 
+and [=attribution source/attribution destination=]. 
+
+Note: One simple priority scheme would be to use the current millisecond timestamp as the priority value.
 
 <h3 id="monkeypatch-navigation">Navigation</h3>
 


### PR DESCRIPTION
This priority is necessary to spec algorithms for handling conversion events, and the browser attribution logic


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/pull/159.html" title="Last updated on Jun 23, 2021, 4:38 PM UTC (bb20ccd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/159/77abb8d...bb20ccd.html" title="Last updated on Jun 23, 2021, 4:38 PM UTC (bb20ccd)">Diff</a>