### PR TITLE
Add priority to AttributionSourceParams and fix IDL types

### DIFF
--- a/event_attribution_reporting_views.md
+++ b/event_attribution_reporting_views.md
@@ -43,10 +43,11 @@ The browser will expose a new interface:
 
 ```
 dictionary AttributionSourceParams {
-  required DOMString attributionSourceEventId;
   required USVString attributionDestination;
-  optional USVString attributionReportTo;
-  optional unsigned long attributionExpiry;
+  required DOMString attributionSourceEventId;
+  USVString attributionReportTo;
+  long long attributionExpiry;
+  long long attributionSourcePriority;
 }
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -84,9 +84,9 @@ Extend the <{a}> element's <a spec=html>DOM interface</a> to include the followi
 
 <pre class="idl">
 partial interface HTMLAnchorElement {
-    [CEReactions] attribute DOMString attributionDestination;
+    [CEReactions] attribute USVString attributionDestination;
     [CEReactions] attribute DOMString attributionSourceEventId;
-    [CEReactions] attribute DOMString attributionReportTo;
+    [CEReactions] attribute USVString attributionReportTo;
     [CEReactions] attribute long long attributionExpiry;
     [CEReactions] attribute long long attributionSourcePriority;
 };


### PR DESCRIPTION
Most notably, add the `attributionSourcePriority` param.

https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/attribution_source_params.idl;drc=7a48dde0857eccf6f61397a962c8532869b861f2


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/184.html" title="Last updated on Jul 15, 2021, 7:26 PM UTC (23823ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/184/1ef789c...apasel422:23823ae.html" title="Last updated on Jul 15, 2021, 7:26 PM UTC (23823ae)">Diff</a>