### PR TITLE
Replace attributeon attribute with attributiondestination in aggregate explainer

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -69,7 +69,7 @@ This adds a new attribute at source registration time (click or view event) call
 ```html
 <a
   attributionsourceeventid="..."
-  attributeon="..."
+  attributiondestination="..."
   attributionreportto="..."
   attributionsourcecontext="campaign123"> ...</a>
 ```


### PR DESCRIPTION
The click and event explainers, as well as the draft spec, specify `attributiondestination` as the name of this attribute.