### PR TITLE
Fix query parameter name of trigger data

### DIFF
--- a/event_attribution_reporting_clicks.md
+++ b/event_attribution_reporting_clicks.md
@@ -191,10 +191,10 @@ this API:
 to trigger attribution for all matching sources.
 
 The browser will treat redirects to a URL of the form:
-`https://<attributionreportto>/.well-known/attribution-reporting/trigger-attribution[?data=<data>&priority=<priority>&dedup-key=<dedup-key>]`
+`https://<attributionreportto>/.well-known/attribution-reporting/trigger-attribution[?trigger-data=<trigger-data>&priority=<priority>&dedup-key=<dedup-key>]`
 
 as a special request. The query string for the request contains additional information about the attribution trigger:
-- `data`: optional data to identify the triggering event
+- `trigger-data`: optional data to identify the triggering event
 - `priority`: optional signed 64-bit integer representing the priority of this trigger compared to other triggers for the same source.
 - `dedup-key`: optional signed 64-bit integer which will be used to deduplicate multiple triggers which contain the same dedup-key for a single source
 

--- a/index.bs
+++ b/index.bs
@@ -442,7 +442,7 @@ To <dfn>obtain an attribution trigger</dfn> given a [=url=] |url| and an
 [=environment settings object=] |environment|, run the following steps:
 
 1. Let |triggerData| be 0.
-1. If |url|'s [=url/query=] has a `"data"` field, set |triggerData| to the result of running [=parse attribution data=] with
+1. If |url|'s [=url/query=] has a `"trigger-data"` field, set |triggerData| to the result of running [=parse attribution data=] with
     the value associated with field modulo the user agent's [=max trigger data value=].
 1. Let |dedupKey| be null.
 1. If |url|'s [=url/query=] has a `"dedup-key"` field, and applying the <a spec="html">rules for


### PR DESCRIPTION
Current implementation in Chrome uses `trigger-data` not `data`.
Ref https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/loader/frame_fetch_context.cc;l=906;drc=2618b478442164f50764871703afacf0a7776fee.

I'm not sure which is the right naming. If the name of `data` is right, please fix Chrome.

Fixes #168


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shigeki/conversion-measurement-api/pull/207.html" title="Last updated on Sep 8, 2021, 7:43 PM UTC (4fab270)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/207/f519bc0...shigeki:4fab270.html" title="Last updated on Sep 8, 2021, 7:43 PM UTC (4fab270)">Diff</a>