### PR TITLE
Add randomly generated ID to reports for deduplication

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -333,6 +333,8 @@ An attribution report is a [=struct=] with the following items:
 :: A point in time.
 : <dfn>source identifier</dfn>
 :: An opaque string.
+: <dfn>nonce</dfn>
+:: A [=string=].
 
 </dl>
 
@@ -639,6 +641,8 @@ To <dfn>obtain a report</dfn> given an [=attribution source=] |source| and an [=
     :: |trigger|'s [=attribution trigger/trigger time=].
     : [=attribution report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
+    : [=attribution report/nonce=]
+    :: The result of [=uuid/generating a random UUID=].
 1. Return |report|.
 
 # Report delivery # {#report-delivery}
@@ -669,6 +673,8 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|:
     :: |report|'s [=attribution report/event id=]
     : `trigger_data`
     :: |report|'s [=attribution report/trigger data=]
+    : `nonce`
+    :: |report|'s [=attribution report/nonce=]
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
 

--- a/index.bs
+++ b/index.bs
@@ -333,7 +333,7 @@ An attribution report is a [=struct=] with the following items:
 :: A point in time.
 : <dfn>source identifier</dfn>
 :: An opaque string.
-: <dfn>nonce</dfn>
+: <dfn>report id</dfn>
 :: A [=string=].
 
 </dl>
@@ -641,8 +641,8 @@ To <dfn>obtain a report</dfn> given an [=attribution source=] |source| and an [=
     :: |trigger|'s [=attribution trigger/trigger time=].
     : [=attribution report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
-    : [=attribution report/nonce=]
-    :: The result of [=uuid/generating a random UUID=].
+    : [=attribution report/report id=]
+    :: A random string.
 1. Return |report|.
 
 # Report delivery # {#report-delivery}
@@ -673,8 +673,8 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|:
     :: |report|'s [=attribution report/event id=]
     : `trigger_data`
     :: |report|'s [=attribution report/trigger data=]
-    : `nonce`
-    :: |report|'s [=attribution report/nonce=]
+    : `report_id`
+    :: |report|'s [=attribution report/report id=]
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
 


### PR DESCRIPTION
Fixes #228


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/231.html" title="Last updated on Oct 7, 2021, 3:35 PM UTC (0c6af12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/231/e05141b...apasel422:0c6af12.html" title="Last updated on Oct 7, 2021, 3:35 PM UTC (0c6af12)">Diff</a>