### PR TITLE
Spec false report attribution mode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -423,21 +423,6 @@ To <dfn>parse an attribution destination</dfn> from a string |str|:
 1. Return the result of [=obtain a site|obtaining a site=] from |url|'s
     [=url/origin=].
 
-<h3 algorithm id="noising-attribution">Noising attribution</h3>
-
-To <dfn>select a random attribution mode</dfn> given doubles |neverRate| and |falselyRate|, run the
-following steps:
-
-1. Assert: |neverRate| is between 0 and 1 (both inclusive).
-1. Assert: |falselyRate| is between 0 and 1 (both inclusive).
-1. Let |noiseRate| be the sum of |neverRate| and |falselyRate|.
-1. Assert: |noiseRate| <= 1.
-1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive).
-1. If |r| is greater than or equal to |noiseRate|, return "<code>truthfully</code>".
-1. Let |t| be a random double between 0 (inclusive) and 1 (exclusive).
-1. If |t| is greater than or equal to |falselyRate|, return "<code>never</code>".
-1. Return "<code>falsely</code>".
-
 <h3 algorithm id="obtaining-attribution-source-anchor">Obtaining an attribution source from an <code>a</code> element</h3>
 
 To <dfn>obtain an attribution source from an anchor</dfn> given an <{a}> element |anchor|:
@@ -474,23 +459,10 @@ To <dfn>obtain an event attribution source from a source</dfn> given an [=attrib
 1. Set |resultSource|'s [=attribution source/source identifier=] to a new unique opaque string.
 1. Set |resultSource|'s [=attribution source/source type=] to "<code>event</code>".
 1. Round |resultSource|'s [=attribution source/expiry=] away from zero to the nearest day (86400 seconds).
-1. Set |resultSource|'s [=attribution source/attribution mode=] to the result of running
-    [=select a random attribution mode=] with the user agent's [=drop report rate=] and
-    the user agent's [=fake report rate=].
+1. Set |resultSource|'s [=attribution source/attribution mode=] to one of
+    "<code>truthfully</code>", "<code>never</code>", or "<code>falsely</code>", with
+    [=implementation-defined=] probability.
 1. Return |resultSource|.
-
-<dfn>Drop report rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive)
-which controls the probability of [=attribution source/attribution mode=] being
-"<code>never</code>".
-
-<dfn>Fake report rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive)
-which controls the probability of [=attribution source/attribution mode=] being
-"<code>falsely</code>".
-
-Note: The user agent's [=drop report rate=] and [=fake report rate=] must sum to no greater than 1.
-For example, to select "<code>truthfully</code>" 75% of the time, "<code>never</code>" 20% of the
-time, and "<code>falsely</code>" 5% of the time, the [=drop report rate=] should be 0.2 and the
-[=fake report rate=] should be 0.05.
 
 <h3 algorithm id="obtaining-attribution-source-params">Obtaining an attribution source from {{AttributionSourceParams}}</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -566,6 +566,8 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
      [=max source cache size=], return.
 1. If |source|'s [=attribution source/attribution mode=] is "<code>falsely</code>", then:
     1. Assert: |source|'s [=attribution source/source type=] is "<code>event</code>".
+    1. If the [=list/size=] of the [=attribution report cache=] is greater than or equal to the user
+        agent's [=max report cache size=], return.
     1. Let |fakeReport| be a new [=attribution report=] with the items:
         : [=attribution report/event id=]
         :: |source|'s [=attribution source/event id=]
@@ -589,8 +591,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Return.
 1. [=set/Append=] |source| to |cache|.
 
-Issue: Should fake reports respect the user agent's [=max report cache size=] and/or
-[=max reports per attribution destination=]?
+Issue: Should fake reports respect the user agent's [=max reports per attribution destination=]?
 
 <dfn>Max source cache size</dfn> is a vendor-specific integer which controls how many
 [=attribution sources=] can be in the [=attribution source cache=].

--- a/index.bs
+++ b/index.bs
@@ -326,9 +326,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>dedup keys</dfn>
 :: [=ordered set=] of [=attribution trigger/dedup keys=] associated with this [=attribution source=].
 : <dfn>attribution mode</dfn>
-:: Either "<code>truthfully</code>" or "<code>never</code>".
-
-Issue: Add a mode that results in fake reports.
+:: Either "<code>truthfully</code>", "<code>never</code>", or "<code>falsely</code>".
 
 </dl>
 
@@ -427,12 +425,16 @@ To <dfn>parse an attribution destination</dfn> from a string |str|:
 
 <h3 algorithm id="noising-attribution">Noising attribution</h3>
 
-To <dfn>select a random attribution mode</dfn> given a double |noiseRate|, run the following steps:
+To <dfn>select a random attribution mode</dfn> given doubles |noiseRate| and |falselyRate|, run the
+following steps:
 
 1. Assert: |noiseRate| is between 0 and 1 (both inclusive).
+1. Assert: |falselyRate| is between 0 and 1 (both inclusive).
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive).
 1. If |r| is greater than or equal to |noiseRate|, return "<code>truthfully</code>".
-1. Return "<code>never</code>".
+1. Let |t| be a random double between 0 (inclusive) and 1 (exclusive).
+1. If |t| is greater than or equal to |falselyRate|, return "<code>never</code>".
+1. Return "<code>falsely</code>".
 
 <h3 algorithm id="obtaining-attribution-source-anchor">Obtaining an attribution source from an <code>a</code> element</h3>
 
@@ -471,11 +473,16 @@ To <dfn>obtain an event attribution source from a source</dfn> given an [=attrib
 1. Set |resultSource|'s [=attribution source/source type=] to "<code>event</code>".
 1. Round |resultSource|'s [=attribution source/expiry=] away from zero to the nearest day (86400 seconds).
 1. Set |resultSource|'s [=attribution source/attribution mode=] to the result of running
-    [=select a random attribution mode=] with the user agent's [=attribution mode noise rate=].
+    [=select a random attribution mode=] with the user agent's [=attribution mode noise rate=] and
+    the user agent's [=fake report rate=].
 1. Return |resultSource|.
 
 <dfn>Attribution mode noise rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive)
 which controls noising of [=attribution source/attribution mode=].
+
+<dfn>Fake report rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive)
+which controls the probability of [=attribution source/attribution mode=] being
+"<code>falsely</code>" versus "<code>never</code>".
 
 <h3 algorithm id="obtaining-attribution-source-params">Obtaining an attribution source from {{AttributionSourceParams}}</h3>
 
@@ -557,7 +564,33 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. [=list/Remove=] all entries in |cache| where the entry's [=attribution source/expiry time=] is less than the current time.
 1. If the [=list/size=] of |cache| is greater than or equal to the user agent's
      [=max source cache size=], return.
+1. If |source|'s [=attribution source/attribution mode=] is "<code>falsely</code>", then:
+    1. Assert: |source|'s [=attribution source/source type=] is "<code>event</code>".
+    1. Let |fakeReport| be a new [=attribution report=] with the items:
+        : [=attribution report/event id=]
+        :: |source|'s [=attribution source/event id=]
+        : [=attribution report/trigger data=]
+        :: A random value between 0 (inclusive) and the user agent's
+            [=max event source trigger data value=] (exclusive)
+        : [=attribution report/reporting endpoint=]
+        :: |source|'s [=attribution source/reporting endpoint=]
+        : [=attribution report/attribution destination=]
+        :: |source|'s [=attribution source/attribution destination=]
+        : [=attribution report/reporting time=]
+        :: The result of running [=obtain a report delivery time=] with |source| and |source|'s
+            [=attribution source/source time=]
+        : [=attribution report/trigger priority=]
+        :: 0
+        : [=attribution report/trigger time=]
+        :: |source|'s [=attribution source/source time=]
+        : [=attribution report/source identifier=]
+        :: |source|'s [=attribution source/source identifier=]
+    1. Add |fakeReport| to the [=attribution report cache=].
+    1. Return.
 1. [=set/Append=] |source| to |cache|.
+
+Issue: Should fake reports respect the user agent's [=max report cache size=] and/or
+[=max reports per attribution destination=]?
 
 <dfn>Max source cache size</dfn> is a vendor-specific integer which controls how many
 [=attribution sources=] can be in the [=attribution source cache=].
@@ -674,6 +707,8 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
       * |a|'s [=attribution source/priority=] is equal to |b|'s [=attribution source/priority=] and |a|'s
          [=attribution source/source time=] is less than |b|'s [=attribution source/source time=].
 1. Let |sourceToAttribute| be the first item in |matchingSources|.
+1. Assert: |sourceToAttribute|'s [=attribution source/attribution mode=] is
+    "<code>truthfully</code>" or "<code>never</code>".
 1. If |trigger|'s [=attribution trigger/dedup key=] is not null and |sourceToAttribute|'s
     [=attribution source/dedup keys=] [=list/contains=] it, return.
 1. Let |numMatchingReports| be the number of entries in the [=attribution report cache=] whose

--- a/index.bs
+++ b/index.bs
@@ -580,7 +580,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         : [=attribution trigger/attribution destination=]
         :: |source|'s [=attribution source/attribution destination=]
         : [=attribution trigger/trigger data=]
-	:: 0
+        :: 0
         : [=attribution trigger/event source trigger data=]
         :: A random value between 0 (inclusive) and the user agent's
             [=max event source trigger data value=] (exclusive)

--- a/index.bs
+++ b/index.bs
@@ -425,11 +425,13 @@ To <dfn>parse an attribution destination</dfn> from a string |str|:
 
 <h3 algorithm id="noising-attribution">Noising attribution</h3>
 
-To <dfn>select a random attribution mode</dfn> given doubles |noiseRate| and |falselyRate|, run the
+To <dfn>select a random attribution mode</dfn> given doubles |neverRate| and |falselyRate|, run the
 following steps:
 
-1. Assert: |noiseRate| is between 0 and 1 (both inclusive).
+1. Assert: |neverRate| is between 0 and 1 (both inclusive).
 1. Assert: |falselyRate| is between 0 and 1 (both inclusive).
+1. Let |noiseRate| be the sum of |neverRate| and |falselyRate|.
+1. Assert: |noiseRate| <= 1.
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive).
 1. If |r| is greater than or equal to |noiseRate|, return "<code>truthfully</code>".
 1. Let |t| be a random double between 0 (inclusive) and 1 (exclusive).
@@ -473,16 +475,22 @@ To <dfn>obtain an event attribution source from a source</dfn> given an [=attrib
 1. Set |resultSource|'s [=attribution source/source type=] to "<code>event</code>".
 1. Round |resultSource|'s [=attribution source/expiry=] away from zero to the nearest day (86400 seconds).
 1. Set |resultSource|'s [=attribution source/attribution mode=] to the result of running
-    [=select a random attribution mode=] with the user agent's [=attribution mode noise rate=] and
+    [=select a random attribution mode=] with the user agent's [=drop report rate=] and
     the user agent's [=fake report rate=].
 1. Return |resultSource|.
 
-<dfn>Attribution mode noise rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive)
-which controls noising of [=attribution source/attribution mode=].
+<dfn>Drop report rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive)
+which controls the probability of [=attribution source/attribution mode=] being
+"<code>never</code>".
 
 <dfn>Fake report rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive)
 which controls the probability of [=attribution source/attribution mode=] being
-"<code>falsely</code>" versus "<code>never</code>".
+"<code>falsely</code>".
+
+Note: The user agent's [=drop report rate=] and [=fake report rate=] must sum to no greater than 1.
+For example, to select "<code>truthfully</code>" 75% of the time, "<code>never</code>" 20% of the
+time, and "<code>falsely</code>" 5% of the time, the [=drop report rate=] should be 0.2 and the
+[=fake report rate=] should be 0.05.
 
 <h3 algorithm id="obtaining-attribution-source-params">Obtaining an attribution source from {{AttributionSourceParams}}</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -568,25 +568,23 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
     1. Assert: |source|'s [=attribution source/source type=] is "<code>event</code>".
     1. If the [=list/size=] of the [=attribution report cache=] is greater than or equal to the user
         agent's [=max report cache size=], return.
-    1. Let |fakeReport| be a new [=attribution report=] with the items:
-        : [=attribution report/event id=]
-        :: |source|'s [=attribution source/event id=]
-        : [=attribution report/trigger data=]
+    1. Let |fakeTrigger| be a new [=attribution trigger=] with the items:
+        : [=attribution trigger/attribution destination=]
+        :: |source|'s [=attribution source/attribution destination=]
+        : [=attribution trigger/trigger data=]
+	:: 0
+        : [=attribution trigger/event source trigger data=]
         :: A random value between 0 (inclusive) and the user agent's
             [=max event source trigger data value=] (exclusive)
-        : [=attribution report/reporting endpoint=]
-        :: |source|'s [=attribution source/reporting endpoint=]
-        : [=attribution report/attribution destination=]
-        :: |source|'s [=attribution source/attribution destination=]
-        : [=attribution report/reporting time=]
-        :: The result of running [=obtain a report delivery time=] with |source| and |source|'s
-            [=attribution source/source time=]
-        : [=attribution report/trigger priority=]
-        :: 0
-        : [=attribution report/trigger time=]
+        : [=attribution trigger/trigger time=]
         :: |source|'s [=attribution source/source time=]
-        : [=attribution report/source identifier=]
-        :: |source|'s [=attribution source/source identifier=]
+        : [=attribution trigger/reporting endpoint=]
+        :: |source|'s [=attribution source/reporting endpoint=]
+        : [=attribution trigger/dedup key=]
+        :: null
+        : [=attribution trigger/priority=]
+        :: 0
+    1. Let |fakeReport| be the result of running [=obtain a report=] with |source| and |fakeTrigger|.
     1. Add |fakeReport| to the [=attribution report cache=].
     1. Return.
 1. [=set/Append=] |source| to |cache|.


### PR DESCRIPTION
When a source's attribution mode is "falsely", the current implementation immediately deactivates it, preventing the source from subsequently being selected during attribution, but since there is no concept of active vs. inactive in the spec, the spec instead skips adding such sources to the source cache entirely.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/251.html" title="Last updated on Nov 8, 2021, 7:38 PM UTC (05f60fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/251/004ca47...apasel422:05f60fe.html" title="Last updated on Nov 8, 2021, 7:38 PM UTC (05f60fe)">Diff</a>