### PR TITLE
Spec report ID for deduplication in the event of retries on network errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Assume Explicit For: on
 <pre class=link-defaults>
 spec:html; type:element; text:a
 spec: uuid; type: dfn; urlPrefix: https://wicg.github.io/uuid/
-    text: generating a random UUID; url: #dfn-generate-a-random-uuid
+    text: generate a random UUID; url: #dfn-generate-a-random-uuid
 </pre>
 
 Introduction {#intro}

--- a/index.bs
+++ b/index.bs
@@ -847,7 +847,7 @@ To <dfn>obtain a report</dfn> given an [=attribution source=] |source| and an [=
     : [=attribution report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
     : [=attribution report/report id=]
-    :: A random string.
+    :: The result of [=generating a random UUID=].
 1. Return |report|.
 
 # Report delivery # {#report-delivery}

--- a/index.bs
+++ b/index.bs
@@ -17,6 +17,8 @@ Assume Explicit For: on
 </pre>
 <pre class=link-defaults>
 spec:html; type:element; text:a
+</pre>
+<pre class="anchors">
 spec: uuid; type: dfn; urlPrefix: https://wicg.github.io/uuid/
     text: generate a random UUID; url: #dfn-generate-a-random-uuid
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -377,6 +377,8 @@ An attribution report is a [=struct=] with the following items:
 :: A string.
 : <dfn>delivered</dfn> (default false)
 :: A boolean.
+: <dfn>report id</dfn>
+:: A string.
 
 </dl>
 
@@ -844,6 +846,8 @@ To <dfn>obtain a report</dfn> given an [=attribution source=] |source| and an [=
     :: |trigger|'s [=attribution trigger/trigger time=].
     : [=attribution report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
+    : [=attribution report/report id=]
+    :: A random string.
 1. Return |report|.
 
 # Report delivery # {#report-delivery}
@@ -887,6 +891,8 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following st
     :: |report|'s [=attribution report/event id=], [=serialize an integer|serialized=]
     : "`trigger_data`"
     :: |report|'s [=attribution report/trigger data=], [=serialize an integer|serialized=]
+    : "`report_id`"
+    :: |report|'s [=attribution report/report id=]
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
 

--- a/index.bs
+++ b/index.bs
@@ -896,6 +896,11 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following st
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
 
+Note: The inclusion of "`report_id`" in the report body is intended to allow the report recipient
+to perform deduplication and prevent double counting, in the event that the user agent retries
+reports on failure. To prevent the report recipient from learning additional information about
+whether a user is online, retries should be limited in number and subject to random delays.
+
 <h3 id="get-report-url">Get report request URL</h3>
 
 To <dfn>generate a report URL</dfn> for a given [=attribution report=] |report|, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Assume Explicit For: on
 <pre class=link-defaults>
 spec:html; type:element; text:a
 spec: uuid; type: dfn; urlPrefix: https://wicg.github.io/uuid/
-  text: generate a random UUID; url: #dfn-generate-a-random-uuid
+    text: generating a random UUID; url: #dfn-generate-a-random-uuid
 </pre>
 
 Introduction {#intro}

--- a/index.bs
+++ b/index.bs
@@ -17,6 +17,8 @@ Assume Explicit For: on
 </pre>
 <pre class=link-defaults>
 spec:html; type:element; text:a
+spec: uuid; type: dfn; urlPrefix: https://wicg.github.io/uuid/
+  text: generate a random UUID; url: #dfn-generate-a-random-uuid
 </pre>
 
 Introduction {#intro}


### PR DESCRIPTION
Fixes #228


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/252.html" title="Last updated on Nov 11, 2021, 6:54 PM UTC (d00ade6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/252/3c7fb7b...apasel422:d00ade6.html" title="Last updated on Nov 11, 2021, 6:54 PM UTC (d00ade6)">Diff</a>