### PR TITLE
Store event id and trigger data as integers, not strings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -794,6 +794,12 @@ To <dfn>queue a report for delivery</dfn> given an [=attribution report=] |repor
     Note: This is intended to allow user agents to optimize device resource usage.
 1. Run [=attempt to deliver a report=] with |report|.
 
+<h3 id="serialize-integer">Serialize an integer</h3>
+
+To <dfn>serialize an integer</dfn>, represent it as a string of the shortest possible decimal number.
+
+Issue: This will be replaced by a more descriptive algorithm in Infra. See infra/201.
+
 <h3 id="serialize-report-body">Serialize attribution report body</h3>
 
 To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following steps:
@@ -807,9 +813,9 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following st
     : "`source_type`"
     :: |report|'s [=attribution report/source type=]
     : "`source_event_id`"
-    :: |report|'s [=attribution report/event id=], [=fetch/serialize an integer|serialized=]
+    :: |report|'s [=attribution report/event id=], [=serialize an integer|serialized=]
     : "`trigger_data`"
-    :: |report|'s [=attribution report/trigger data=], [=fetch/serialize an integer|serialized=]
+    :: |report|'s [=attribution report/trigger data=], [=serialize an integer|serialized=]
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
 

--- a/index.bs
+++ b/index.bs
@@ -304,7 +304,7 @@ An attribution source is a [=struct=] with the following items:
 
 <dl dfn-for="attribution source">
 : <dfn>source identifier</dfn>
-:: A string.
+:: A [=string=].
 : <dfn>source origin</dfn>
 :: An [=url/origin=].
 : <dfn>event id</dfn>
@@ -340,9 +340,9 @@ An attribution trigger is a [=struct=] with the following items:
 : <dfn>attribution destination</dfn>
 :: A [=site=].
 : <dfn>trigger data</dfn>
-:: A [=string=].
+:: A non-negative 64-bit integer.
 : <dfn>event source trigger data</dfn>
-:: A [=string=].
+:: A non-negative 64-bit integer.
 : <dfn>trigger time</dfn>
 :: A point in time.
 : <dfn>reporting endpoint</dfn>
@@ -360,11 +360,11 @@ An attribution report is a [=struct=] with the following items:
 
 <dl dfn-for="attribution report">
 : <dfn>event id</dfn>
-:: A [=string=].
+:: A non-negative 64-bit integer.
 : <dfn>source type</dfn>
 :: Either "<code>navigation</code>" or "<code>event</code>".
 : <dfn>trigger data</dfn>
-:: A [=string=].
+:: A non-negative 64-bit integer.
 : <dfn>reporting endpoint</dfn>
 :: An [=url/origin=].
 : <dfn>attribution destination</dfn>
@@ -402,7 +402,7 @@ An [=attribution source=] |source|'s <dfn for="attribution source">expiry time</
 
 <h3 algorithm id="parsing-data-fields">Parsing data fields</h3>
 
-This section defines how to parse and extract
+This section defines how to parse strings into integers for
 [=attribution source/event id=], [=attribution trigger/trigger data=], and [=attribution trigger/event source trigger data=].
 
 To <dfn>parse attribution data</dfn> given a [=string=] |input| modulo an integer
@@ -812,6 +812,10 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following st
     :: |report|'s [=attribution report/trigger data=]
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
+
+Issue: How can we force [=attribution report/event id=] and [=attribution report/trigger data=] to
+be serialized as JSON strings, since JSON numbers don't necessarily support all possible values of
+unsigned 64-bit integers?
 
 <h3 id="get-report-url">Get report request URL</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -798,7 +798,7 @@ To <dfn>queue a report for delivery</dfn> given an [=attribution report=] |repor
 
 To <dfn>serialize an integer</dfn>, represent it as a string of the shortest possible decimal number.
 
-Issue: This will be replaced by a more descriptive algorithm in Infra. See
+Issue: This would ideally be replaced by a more descriptive algorithm in Infra. See
 <a href="https://github.com/whatwg/infra/issues/201">infra/201</a>
 
 <h3 id="serialize-report-body">Serialize attribution report body</h3>

--- a/index.bs
+++ b/index.bs
@@ -807,15 +807,11 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following st
     : "`source_type`"
     :: |report|'s [=attribution report/source type=]
     : "`source_event_id`"
-    :: |report|'s [=attribution report/event id=]
+    :: |report|'s [=attribution report/event id=], [=fetch/serialize an integer|serialized=]
     : "`trigger_data`"
-    :: |report|'s [=attribution report/trigger data=]
+    :: |report|'s [=attribution report/trigger data=], [=fetch/serialize an integer|serialized=]
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
-
-Issue: How can we force [=attribution report/event id=] and [=attribution report/trigger data=] to
-be serialized as JSON strings, since JSON numbers don't necessarily support all possible values of
-unsigned 64-bit integers?
 
 <h3 id="get-report-url">Get report request URL</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -798,7 +798,8 @@ To <dfn>queue a report for delivery</dfn> given an [=attribution report=] |repor
 
 To <dfn>serialize an integer</dfn>, represent it as a string of the shortest possible decimal number.
 
-Issue: This will be replaced by a more descriptive algorithm in Infra. See infra/201.
+Issue: This will be replaced by a more descriptive algorithm in Infra. See
+<a href="https://github.com/whatwg/infra/issues/201">infra/201</a>
 
 <h3 id="serialize-report-body">Serialize attribution report body</h3>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/266.html" title="Last updated on Nov 5, 2021, 7:00 PM UTC (21a61bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/266/cabacc3...apasel422:21a61bd.html" title="Last updated on Nov 5, 2021, 7:00 PM UTC (21a61bd)">Diff</a>