### PR TITLE
Reformulate noising as randomized responses

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -499,10 +499,10 @@ To <dfn>obtain an event attribution source from a source</dfn> given an [=attrib
 1. Set |resultSource|'s [=attribution source/attribution mode=] to the result of
     [=obtaining a randomized response=] with "`truthfully`",
     «"`truthfully`", "`never`", "`falsely`"», and the user agent's
-    [=event source false trigger probability=].
+    [=event-source false trigger probability=].
 1. Return |resultSource|.
 
-<dfn>Event source false trigger probability</dfn> is a vendor-specific double between 0 and 1 (both
+<dfn>Event-source false trigger probability</dfn> is a vendor-specific double between 0 and 1 (both
 inclusive) that controls the randomized response probability for the
 [=attribution source/attribution mode=] of an [=attribution source=] whose
 [=attribution source/source type=] is "`event`".

--- a/index.bs
+++ b/index.bs
@@ -516,10 +516,10 @@ To <dfn>obtain an event attribution source from a source</dfn> given an [=attrib
 1. Set |resultSource|'s [=attribution source/attribution mode=] to the result of
     [=obtaining a random attribution mode=] with the user agent's
     [=event-source trigger data cardinality=] and the user agent's
-    [=event-source randomized trigger probability=].
+    [=randomized event-source trigger rate=].
 1. Return |resultSource|.
 
-<dfn>Event-source randomized trigger probability</dfn> is a vendor-specific double between 0 and 1 (both
+<dfn>Randomized event-source trigger rate</dfn> is a vendor-specific double between 0 and 1 (both
 inclusive) that controls the randomized response probability for the
 [=attribution source/attribution mode=] of an [=attribution source=] whose
 [=attribution source/source type=] is "`event`".

--- a/index.bs
+++ b/index.bs
@@ -470,7 +470,7 @@ To <dfn>parse an attribution destination</dfn> from a string |str|:
 <h3 algorithm id="obtaining-random-attribution-mode">Obtaining a random attribution mode</h3>
 
 To <dfn>obtain a random attribution mode</dfn> given a positive integer |triggerDataCardinality|
-and a double |randomizedPickRate|:
+and a double |randomPickRate|:
 
 1. Let |possibleValues| be the [=set=] of [=attribution modes=]
     « (`"truthfully"`, null), (`"never"`, null) ».

--- a/index.bs
+++ b/index.bs
@@ -678,7 +678,7 @@ To <dfn>obtain an attribution trigger</dfn> given a [=URL=] |url| and an
 [=attribution trigger/trigger data=]:
 0 <= [=attribution trigger/trigger data=] < [=trigger data cardinality=].
 
-<dfn>Event-source trigger cardinality</dfn> is a vendor-specific integer that controls the valid
+<dfn>Event-source trigger data cardinality</dfn> is a vendor-specific integer that controls the valid
 range of [=attribution trigger/event source trigger data=]:
 0 <= [=attribution trigger/event source trigger data=] < [=event-source trigger data cardinality=].
 

--- a/index.bs
+++ b/index.bs
@@ -416,6 +416,19 @@ shared among all [=environment settings objects=].
 Note: This would ideally use <a spec=storage>storage bottles</a> to provide access to the attribution caches.
 However attribution data is inherently cross-site, and operations on storage would need to span across all storage bottle maps.
 
+# General Algorithms # {#general-algorithms}
+
+<h3 id="obtaining-randomized-response">Obtaining a randomized response</h3>
+
+To <dfn>obtain a randomized response</dfn> given |trueInput|, a [=set=] |possibleInputs|, and a
+double |falseRate|:
+
+1. Assert: |possibleInputs| [=list/contains=] |trueInput|.
+1. Assert: |falseRate| is between 0 and 1 (both inclusive).
+1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with uniform probability.
+1. If |r| is greater than or equal to |falseRate|, return |trueInput|.
+1. Otherwise, return a random [=item=] from |possibleInputs| with uniform probability.
+
 # Source Algorithms # {#source-algorithms}
 
 <h3 id="obtaining-attribution-source-expiry-time">Obtaining an attribution source's expiry time</h3>
@@ -483,10 +496,16 @@ To <dfn>obtain an event attribution source from a source</dfn> given an [=attrib
 1. Set |resultSource|'s [=attribution source/source identifier=] to a new unique opaque string.
 1. Set |resultSource|'s [=attribution source/source type=] to "<code>event</code>".
 1. Round |resultSource|'s [=attribution source/expiry=] away from zero to the nearest day (86400 seconds).
-1. Set |resultSource|'s [=attribution source/attribution mode=] to one of
-    "<code>truthfully</code>", "<code>never</code>", or "<code>falsely</code>", with
-    [=implementation-defined=] probability.
+1. Set |resultSource|'s [=attribution source/attribution mode=] to the result of
+    [=obtaining a randomized response=] with "`truthfully`",
+    «"`truthfully`", "`never`", "`falsely`"», and the user agent's
+    [=event source false trigger probability=].
 1. Return |resultSource|.
+
+<dfn>Event source false trigger probability</dfn> is a vendor-specific double between 0 and 1 (both
+inclusive) that controls the randomized response probability for the
+[=attribution source/attribution mode=] of an [=attribution source=] whose
+[=attribution source/source type=] is "`event`".
 
 <h3 algorithm id="obtaining-attribution-source-params">Obtaining an attribution source from {{AttributionSourceParams}}</h3>
 
@@ -605,14 +624,12 @@ Issue: Should fake reports respect the user agent's [=max reports per attributio
 This section defines how to noise [=attribution trigger/trigger data=] and
 [=attribution trigger/event source trigger data=].
 
-To <dfn>noise trigger data</dfn> given an integer |input|, integer |maxData|, and double |noiseRate|,
+To <dfn>noise trigger data</dfn> given an integer |input|, integer |max|, and double |noiseRate|,
 run the following steps:
 
-1. Assert: |input| is between 0 (inclusive) and |maxData| exclusive.
-1. Assert: |noiseRate| is between 0 and 1 (both inclusive).
-1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive).
-1. If |r| is greater than or equal to |noiseRate|, return |input|.
-1. Return a random integer between 0 (inclusive) and |maxData| (exclusive).
+1. Let |possibleInputs| be a [=set=] containing the integers between 0 and |max| (both inclusive).
+1. Return the result of [=obtaining a randomized response=] with |input|, |possibleInputs|, and
+    |noiseRate|.
 
 <h3 algorithm id="attribution-trigger-creation">Creating an attribution trigger</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -302,6 +302,12 @@ This specification defines a [=policy-controlled feature=] identified by the str
 
 # Structures # {#structures}
 
+<h3 dfn-type=dfn>Attribution mode</h3>
+
+An attribution mode is a [=tuple=] consisting of a mode and a random trigger data. The mode is
+either "`truthfully`", "`never`", or "`falsely`". The random trigger data is a non-negative 64-bit
+integer, if the mode is "`falsely`", or null otherwise.
+
 <h3 dfn-type=dfn>Attribution source</h3>
 
 An attribution source is a [=struct=] with the following items:
@@ -330,7 +336,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>dedup keys</dfn>
 :: [=ordered set=] of [=attribution trigger/dedup keys=] associated with this [=attribution source=].
 : <dfn>attribution mode</dfn>
-:: Either "<code>truthfully</code>", "<code>never</code>", or "<code>falsely</code>".
+:: An [=attribution mode=].
 
 </dl>
 
@@ -461,6 +467,18 @@ To <dfn>parse an attribution destination</dfn> from a string |str|:
 1. Return the result of [=obtain a site|obtaining a site=] from |url|'s
     [=url/origin=].
 
+<h3 algorithm id="obtaining-random-attribution-mode">Obtaining a random attribution mode</h3>
+
+To <dfn>obtain a random attribution mode</dfn> given a positive integer |triggerDataCardinality|
+and a double |randomizedPickRate|:
+
+1. Let |possibleValues| be the [=set=] of [=attribution modes=]
+    « (`"truthfully"`, null), (`"never"`, null) ».
+1. For each integer |i| between 0 (inclusive) and |triggerDataCardinality| (exclusive):
+    1. [=set/Append=] the [=attribution mode=] (`"falsely"`, |i|) to |possibleValues|.
+1. Return the result of [=obtaining a randomized response=] with (`"truthfully"`, null), |possibleValues|, and
+    |randomPickRate|.
+
 <h3 algorithm id="obtaining-attribution-source-anchor">Obtaining an attribution source from an <code>a</code> element</h3>
 
 To <dfn>obtain an attribution source from an anchor</dfn> given an <{a}> element |anchor|:
@@ -498,12 +516,12 @@ To <dfn>obtain an event attribution source from a source</dfn> given an [=attrib
 1. Set |resultSource|'s [=attribution source/source type=] to "<code>event</code>".
 1. Round |resultSource|'s [=attribution source/expiry=] away from zero to the nearest day (86400 seconds).
 1. Set |resultSource|'s [=attribution source/attribution mode=] to the result of
-    [=obtaining a randomized response=] with "`truthfully`",
-    «"`truthfully`", "`never`", "`falsely`"», and the user agent's
-    [=event-source false trigger probability=].
+    [=obtaining a random attribution mode=] with the user agent's
+    [=event-source trigger data cardinality=] and the user agent's
+    [=event-source randomized trigger probability=].
 1. Return |resultSource|.
 
-<dfn>Event-source false trigger probability</dfn> is a vendor-specific double between 0 and 1 (both
+<dfn>Event-source randomized trigger probability</dfn> is a vendor-specific double between 0 and 1 (both
 inclusive) that controls the randomized response probability for the
 [=attribution source/attribution mode=] of an [=attribution source=] whose
 [=attribution source/source type=] is "`event`".
@@ -559,7 +577,7 @@ and an [=environment settings object=] |settings|, run the following steps:
     : [=attribution source/source type=]
     :: "<code>navigation</code>"
     : [=attribution source/attribution mode=]
-    :: "<code>truthfully</code>"
+    :: ("`truthfully`", null)
 1. Return |source|.
 
 <dfn>Max event id value</dfn> is a vendor-specific integer which controls
@@ -588,7 +606,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. [=list/Remove=] all entries in |cache| where the entry's [=attribution source/expiry time=] is less than the current time.
 1. If the [=list/size=] of |cache| is greater than or equal to the user agent's
      [=max source cache size=], return.
-1. If |source|'s [=attribution source/attribution mode=] is "<code>falsely</code>", then:
+1. If |source|'s [=attribution source/attribution mode=][0] is "`falsely`", then:
     1. Assert: |source|'s [=attribution source/source type=] is "<code>event</code>".
     1. If the [=list/size=] of the [=attribution report cache=] is greater than or equal to the user
         agent's [=max report cache size=], return.
@@ -598,8 +616,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         : [=attribution trigger/trigger data=]
         :: 0
         : [=attribution trigger/event source trigger data=]
-        :: A random value between 0 (inclusive) and the user agent's
-            [=event-source trigger data cardinality=] (exclusive)
+        :: |source|'s [=attribution source/attribution mode=][1]
         : [=attribution trigger/trigger time=]
         :: |source|'s [=attribution source/source time=]
         : [=attribution trigger/reporting endpoint=]
@@ -759,8 +776,8 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
       * |a|'s [=attribution source/priority=] is equal to |b|'s [=attribution source/priority=] and |a|'s
          [=attribution source/source time=] is less than |b|'s [=attribution source/source time=].
 1. Let |sourceToAttribute| be the first item in |matchingSources|.
-1. Assert: |sourceToAttribute|'s [=attribution source/attribution mode=] is
-    "<code>truthfully</code>" or "<code>never</code>".
+1. Assert: |sourceToAttribute|'s [=attribution source/attribution mode=][0] is
+    "`truthfully`" or "`never`".
 1. If |trigger|'s [=attribution trigger/dedup key=] is not null and |sourceToAttribute|'s
     [=attribution source/dedup keys=] [=list/contains=] it, return.
 1. Let |numMatchingReports| be the number of entries in the [=attribution report cache=] whose
@@ -790,7 +807,7 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
     1. [=list/Remove=] |item| from the [=attribution source cache=].
 1. If the [=list/size=] of the [=attribution report cache=] is greater than or equal to the user
     agent's [=max report cache size=], return.
-1. If |sourceToAttribute|'s [=attribution source/attribution mode=] is "<code>truthfully</code>",
+1. If |sourceToAttribute|'s [=attribution source/attribution mode=][0] is "`truthfully`",
     add |report| to the [=attribution report cache=].
 1. Increment |sourceToAttribute|'s [=attribution source/number of reports=] value by 1.
 1. If |trigger|'s [=attribution trigger/dedup key=] is not null, [=list/append=] it to |sourceToAttribute|'s

--- a/index.bs
+++ b/index.bs
@@ -420,14 +420,15 @@ However attribution data is inherently cross-site, and operations on storage wou
 
 <h3 id="obtaining-randomized-response">Obtaining a randomized response</h3>
 
-To <dfn>obtain a randomized response</dfn> given |trueInput|, a [=set=] |possibleInputs|, and a
-double |falseRate|:
+To <dfn>obtain a randomized response</dfn> given |trueValue|, a [=set=] |possibleValues|, and a
+double |randomPickRate|:
 
-1. Assert: |possibleInputs| [=list/contains=] |trueInput|.
-1. Assert: |falseRate| is between 0 and 1 (both inclusive).
+1. Assert: |possibleValues| [=list/contains=] |trueValue|.
+1. Assert: |randomPickRate| is between 0 and 1 (both inclusive).
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with uniform probability.
-1. If |r| is greater than or equal to |falseRate|, return |trueInput|.
-1. Otherwise, return a random item from |possibleInputs| with uniform probability.
+1. If |r| is less than |randomPickRate|, return a random item from |possibleValues| with uniform
+    probability.
+1. Otherwise, return |trueValue|.
 
 # Source Algorithms # {#source-algorithms}
 
@@ -624,13 +625,13 @@ Issue: Should fake reports respect the user agent's [=max reports per attributio
 This section defines how to noise [=attribution trigger/trigger data=] and
 [=attribution trigger/event source trigger data=].
 
-To <dfn>noise trigger data</dfn> given an integer |input|, integer |cardinality|, and double |falseRate|,
+To <dfn>noise trigger data</dfn> given an integer |input|, integer |cardinality|, and double |randomPickRate|,
 run the following steps:
 
-1. Let |possibleInputs| be a [=set=] containing the integers between 0 (inclusive) and
+1. Let |possibleValues| be a [=set=] containing the integers between 0 (inclusive) and
     |cardinality| (exclusive).
-1. Return the result of [=obtaining a randomized response=] with |input|, |possibleInputs|, and
-    |falseRate|.
+1. Return the result of [=obtaining a randomized response=] with |input|, |possibleValues|, and
+    |randomPickRate|.
 
 <h3 algorithm id="attribution-trigger-creation">Creating an attribution trigger</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -429,7 +429,6 @@ However attribution data is inherently cross-site, and operations on storage wou
 To <dfn>obtain a randomized response</dfn> given |trueValue|, a [=set=] |possibleValues|, and a
 double |randomPickRate|:
 
-1. Assert: |possibleValues| [=list/contains=] |trueValue|.
 1. Assert: |randomPickRate| is between 0 and 1 (both inclusive).
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with uniform probability.
 1. If |r| is less than |randomPickRate|, return a random item from |possibleValues| with uniform
@@ -472,12 +471,11 @@ To <dfn>parse an attribution destination</dfn> from a string |str|:
 To <dfn>obtain a random attribution mode</dfn> given a positive integer |triggerDataCardinality|
 and a double |randomPickRate|:
 
-1. Let |possibleValues| be the [=set=] of [=attribution modes=]
-    « (`"truthfully"`, null), (`"never"`, null) ».
+1. Let |possibleValues| be the [=set=] of [=attribution modes=] « (`"never"`, null) ».
 1. For each integer |i| between 0 (inclusive) and |triggerDataCardinality| (exclusive):
     1. [=set/Append=] the [=attribution mode=] (`"falsely"`, |i|) to |possibleValues|.
-1. Return the result of [=obtaining a randomized response=] with (`"truthfully"`, null), |possibleValues|, and
-    |randomPickRate|.
+1. Return the result of [=obtaining a randomized response=] with the [=attribution mode=]
+    (`"truthfully"`, null), |possibleValues|, and |randomPickRate|.
 
 <h3 algorithm id="obtaining-attribution-source-anchor">Obtaining an attribution source from an <code>a</code> element</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -598,7 +598,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: 0
         : [=attribution trigger/event source trigger data=]
         :: A random value between 0 (inclusive) and the user agent's
-            [=event-source trigger data cardinality] (exclusive)
+            [=event-source trigger data cardinality=] (exclusive)
         : [=attribution trigger/trigger time=]
         :: |source|'s [=attribution source/source time=]
         : [=attribution trigger/reporting endpoint=]

--- a/index.bs
+++ b/index.bs
@@ -657,13 +657,13 @@ To <dfn>obtain an attribution trigger</dfn> given a [=URL=] |url| and an
 1. If |url|'s [=url/query=] has a "`trigger-data`" field, set |triggerData| to the result of running [=parse attribution data=] with
     the value associated with the field modulo the user agent's [=trigger data cardinality=].
 1. Set |triggerData| to the result of running [=noise trigger data=] with |triggerData|, the
-    user agent's [=trigger data cardinality=], and the user agent's [=false trigger data probability=].
+    user agent's [=trigger data cardinality=], and the user agent's [=randomized trigger data rate=].
 1. Let |eventSourceTriggerData| be 0.
 1. If |url|'s [=url/query=] has an "`event-source-trigger-data`" field, set |eventSourceTriggerData| to the result of running [=parse attribution data=] with
     the value associated with the field modulo the user agent's [=event-source trigger data cardinality=].
 1. Set |eventSourceTriggerData| to the result of running [=noise trigger data=] with
     |eventSourceTriggerData|, the user agent's [=event-source trigger data cardinality=], and the
-    user agent's [=false event-source trigger data probability=].
+    user agent's [=randomized event-source trigger data rate=].
 1. Let |dedupKey| be null.
 1. If |url|'s [=url/query=] has a "`dedup-key`" field, and applying the <a spec="html">rules for
     parsing integers</a> to the field's value results in an integer, then set |dedupKey| to that
@@ -698,11 +698,11 @@ To <dfn>obtain an attribution trigger</dfn> given a [=URL=] |url| and an
 range of [=attribution trigger/event source trigger data=]:
 0 <= [=attribution trigger/event source trigger data=] < [=event-source trigger data cardinality=].
 
-<dfn>False trigger data probability</dfn> is a vendor-specific double between 0 and 1 (both
+<dfn>Randomized trigger data rate</dfn> is a vendor-specific double between 0 and 1 (both
 inclusive) that controls the randomized response probability for
 [=attribution trigger/trigger data=].
 
-<dfn>False event-source trigger data probability</dfn> is a vendor-specific double between 0 and 1
+<dfn>Randomized event-source trigger data rate</dfn> is a vendor-specific double between 0 and 1
 (both inclusive) that controls the randomized response probability for
 [=attribution trigger/event source trigger data=].
 

--- a/index.bs
+++ b/index.bs
@@ -427,7 +427,7 @@ double |falseRate|:
 1. Assert: |falseRate| is between 0 and 1 (both inclusive).
 1. Let |r| be a random double between 0 (inclusive) and 1 (exclusive) with uniform probability.
 1. If |r| is greater than or equal to |falseRate|, return |trueInput|.
-1. Otherwise, return a random [=item=] from |possibleInputs| with uniform probability.
+1. Otherwise, return a random item from |possibleInputs| with uniform probability.
 
 # Source Algorithms # {#source-algorithms}
 
@@ -598,7 +598,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: 0
         : [=attribution trigger/event source trigger data=]
         :: A random value between 0 (inclusive) and the user agent's
-            [=max event source trigger data value=] (exclusive)
+            [=event-source trigger data cardinality] (exclusive)
         : [=attribution trigger/trigger time=]
         :: |source|'s [=attribution source/source time=]
         : [=attribution trigger/reporting endpoint=]
@@ -624,12 +624,13 @@ Issue: Should fake reports respect the user agent's [=max reports per attributio
 This section defines how to noise [=attribution trigger/trigger data=] and
 [=attribution trigger/event source trigger data=].
 
-To <dfn>noise trigger data</dfn> given an integer |input|, integer |max|, and double |noiseRate|,
+To <dfn>noise trigger data</dfn> given an integer |input|, integer |cardinality|, and double |falseRate|,
 run the following steps:
 
-1. Let |possibleInputs| be a [=set=] containing the integers between 0 and |max| (both inclusive).
+1. Let |possibleInputs| be a [=set=] containing the integers between 0 (inclusive) and
+    |cardinality| (exclusive).
 1. Return the result of [=obtaining a randomized response=] with |input|, |possibleInputs|, and
-    |noiseRate|.
+    |falseRate|.
 
 <h3 algorithm id="attribution-trigger-creation">Creating an attribution trigger</h3>
 
@@ -638,15 +639,15 @@ To <dfn>obtain an attribution trigger</dfn> given a [=URL=] |url| and an
 
 1. Let |triggerData| be 0.
 1. If |url|'s [=url/query=] has a "`trigger-data`" field, set |triggerData| to the result of running [=parse attribution data=] with
-    the value associated with the field modulo the user agent's [=max trigger data value=].
+    the value associated with the field modulo the user agent's [=trigger data cardinality=].
 1. Set |triggerData| to the result of running [=noise trigger data=] with |triggerData|, the
-    user agent's [=max trigger data value=], and the user agent's [=trigger data noise rate=].
+    user agent's [=trigger data cardinality=], and the user agent's [=false trigger data probability=].
 1. Let |eventSourceTriggerData| be 0.
 1. If |url|'s [=url/query=] has an "`event-source-trigger-data`" field, set |eventSourceTriggerData| to the result of running [=parse attribution data=] with
-    the value associated with the field modulo the user agent's [=max event source trigger data value=].
+    the value associated with the field modulo the user agent's [=event-source trigger data cardinality=].
 1. Set |eventSourceTriggerData| to the result of running [=noise trigger data=] with
-    |eventSourceTriggerData|, the user agent's [=max event source trigger data value=], and the
-    user agent's [=event source trigger data noise rate=].
+    |eventSourceTriggerData|, the user agent's [=event-source trigger data cardinality=], and the
+    user agent's [=false event-source trigger data probability=].
 1. Let |dedupKey| be null.
 1. If |url|'s [=url/query=] has a "`dedup-key`" field, and applying the <a spec="html">rules for
     parsing integers</a> to the field's value results in an integer, then set |dedupKey| to that
@@ -673,13 +674,21 @@ To <dfn>obtain an attribution trigger</dfn> given a [=URL=] |url| and an
     :: |triggerPriority|.
 1. Return |trigger|.
 
-<dfn>Max trigger data value</dfn> is a vendor-specific integer which controls the potential values of [=attribution trigger/trigger data=].
+<dfn>Trigger data cardinality</dfn> is a vendor-specific integer that controls the valid range of
+[=attribution trigger/trigger data=]:
+0 <= [=attribution trigger/trigger data=] < [=trigger data cardinality=].
 
-<dfn>Max event source trigger data value</dfn> is a vendor-specific integer which controls the potential values of [=attribution trigger/event source trigger data=].
+<dfn>Event-source trigger cardinality</dfn> is a vendor-specific integer that controls the valid
+range of [=attribution trigger/event source trigger data=]:
+0 <= [=attribution trigger/event source trigger data=] < [=event-source trigger data cardinality=].
 
-<dfn>Trigger data noise rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive) which controls noising of [=attribution trigger/trigger data=].
+<dfn>False trigger data probability</dfn> is a vendor-specific double between 0 and 1 (both
+inclusive) that controls the randomized response probability for
+[=attribution trigger/trigger data=].
 
-<dfn>Event source trigger data noise rate</dfn> is a vendor-specific double between 0 and 1 (both inclusive) which controls noising of [=attribution trigger/event source trigger data=].
+<dfn>False event-source trigger data probability</dfn> is a vendor-specific double between 0 and 1
+(both inclusive) that controls the randomized response probability for
+[=attribution trigger/event source trigger data=].
 
 Issue: Formalize how to parse the query similar to URLSearchParams.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 6, 2022, 8:10 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fapasel422%2Fconversion-measurement-api%2Fd5960ff3fadb15c7f51c63d1950557cfd45699dd%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/conversion-measurement-api%23279.)._
</details>
