### PR TITLE
Rename dedup-key and report_id to client-deduplication-key and server-deduplication-key, respectively

### DIFF
--- a/event_attribution_reporting_clicks.md
+++ b/event_attribution_reporting_clicks.md
@@ -194,12 +194,12 @@ this API:
 to trigger attribution for all matching sources.
 
 The browser will treat redirects to a URL of the form:
-`https://<attributionreportto>/.well-known/attribution-reporting/trigger-attribution[?trigger-data=<trigger-data>&priority=<priority>&dedup-key=<dedup-key>]`
+`https://<attributionreportto>/.well-known/attribution-reporting/trigger-attribution[?trigger-data=<trigger-data>&priority=<priority>&client-deduplication-key=<client-deduplication-key>]`
 
 as a special request. The query string for the request contains additional information about the attribution trigger:
 - `trigger-data`: optional data to identify the triggering event
 - `priority`: optional signed 64-bit integer representing the priority of this trigger compared to other triggers for the same source.
-- `dedup-key`: optional signed 64-bit integer which will be used to deduplicate multiple triggers which contain the same dedup-key for a single source
+- `client-deduplication-key`: optional signed 64-bit integer which will be used to deduplicate multiple triggers which contain the same client-deduplication-key for a single source
 
 When the special redirect is detected, the browser will schedule an attribution
 report as detailed in [Trigger attribution algorithm](#trigger-attribution-algorithm).
@@ -238,10 +238,10 @@ the greatest `attributionsourcepriority`. If multiple sources have the greatest
 recently.
 
 The browser then schedules a report for the source that was picked by storing
- {`attributionreportto`, `attributiondestination` eTLD+1, `attributionsourceeventid`, [decoded](#data-encoding) trigger-data, priority, dedup-key} for the source.
+ {`attributionreportto`, `attributiondestination` eTLD+1, `attributionsourceeventid`, [decoded](#data-encoding) trigger-data, priority, client-deduplication-key} for the source.
 Scheduled reports will be sent as detailed in [Sending scheduled reports](#sending-scheduled-reports).
 
-The browser will only create reports for a source if the trigger's dedup-key has not already been associated with a report for that source.
+The browser will only create reports for a source if the trigger's client-deduplication-key has not already been associated with a report for that source.
 
 Each source is only allowed to schedule a maximum of three reports
 (see [Triggering attribution multiple times for the same source](#triggering-attribution-multiple-times-for-the-same-source)). The browser will delete sources which have sent three reports.

--- a/index.bs
+++ b/index.bs
@@ -333,8 +333,8 @@ An attribution source is a [=struct=] with the following items:
 :: A point in time.
 : <dfn>number of reports</dfn>
 :: Number of [=attribution reports=] created for this [=attribution source=].
-: <dfn>dedup keys</dfn>
-:: [=ordered set=] of [=attribution trigger/dedup keys=] associated with this [=attribution source=].
+: <dfn>client deduplication keys</dfn>
+:: [=ordered set=] of [=attribution trigger/client deduplication keys=] associated with this [=attribution source=].
 : <dfn>attribution mode</dfn>
 :: An [=attribution mode=].
 
@@ -355,7 +355,7 @@ An attribution trigger is a [=struct=] with the following items:
 :: A point in time.
 : <dfn>reporting endpoint</dfn>
 :: An [=url/origin=].
-: <dfn>dedup key</dfn>
+: <dfn>client deduplication key</dfn>
 :: Null or a 64-bit integer.
 : <dfn>priority</dfn>
 :: A 64-bit integer.
@@ -387,7 +387,7 @@ An attribution report is a [=struct=] with the following items:
 :: A string.
 : <dfn>delivered</dfn> (default false)
 :: A boolean.
-: <dfn>report id</dfn>
+: <dfn>server deduplication key</dfn>
 :: A string.
 
 </dl>
@@ -619,7 +619,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
         :: |source|'s [=attribution source/source time=]
         : [=attribution trigger/reporting endpoint=]
         :: |source|'s [=attribution source/reporting endpoint=]
-        : [=attribution trigger/dedup key=]
+        : [=attribution trigger/client deduplication key=]
         :: null
         : [=attribution trigger/priority=]
         :: 0
@@ -664,9 +664,9 @@ To <dfn>obtain an attribution trigger</dfn> given a [=URL=] |url| and an
 1. Set |eventSourceTriggerData| to the result of running [=noise trigger data=] with
     |eventSourceTriggerData|, the user agent's [=event-source trigger data cardinality=], and the
     user agent's [=randomized event-source trigger data rate=].
-1. Let |dedupKey| be null.
-1. If |url|'s [=url/query=] has a "`dedup-key`" field, and applying the <a spec="html">rules for
-    parsing integers</a> to the field's value results in an integer, then set |dedupKey| to that
+1. Let |clientDeduplicationKey| be null.
+1. If |url|'s [=url/query=] has a "`client-deduplication-key`" field, and applying the <a spec="html">rules for
+    parsing integers</a> to the field's value results in an integer, then set |clientDeduplicationKey| to that
     value.
 1. Let |triggerPriority| be 0.
 1. If |url|'s [=url/query=] has a "`priority`" field, and applying the
@@ -684,8 +684,8 @@ To <dfn>obtain an attribution trigger</dfn> given a [=URL=] |url| and an
     :: The current time.
     : [=attribution trigger/reporting endpoint=]
     :: |url|'s [=url/origin=].
-    : [=attribution trigger/dedup key=]
-    :: |dedupKey|.
+    : [=attribution trigger/client deduplication key=]
+    :: |clientDeduplicationKey|.
     : [=attribution trigger/priority=]
     :: |triggerPriority|.
 1. Return |trigger|.
@@ -776,8 +776,8 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
 1. Let |sourceToAttribute| be the first item in |matchingSources|.
 1. Assert: |sourceToAttribute|'s [=attribution source/attribution mode=][0] is
     "`truthfully`" or "`never`".
-1. If |trigger|'s [=attribution trigger/dedup key=] is not null and |sourceToAttribute|'s
-    [=attribution source/dedup keys=] [=list/contains=] it, return.
+1. If |trigger|'s [=attribution trigger/client deduplication key=] is not null and |sourceToAttribute|'s
+    [=attribution source/client deduplication keys=] [=list/contains=] it, return.
 1. Let |numMatchingReports| be the number of entries in the [=attribution report cache=] whose
     [=attribution report/attribution destination=] equals |attributionDestination|.
 1. If |numMatchingReports| is greater than or equal to the user agent's
@@ -808,8 +808,8 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
 1. If |sourceToAttribute|'s [=attribution source/attribution mode=][0] is "`truthfully`",
     add |report| to the [=attribution report cache=].
 1. Increment |sourceToAttribute|'s [=attribution source/number of reports=] value by 1.
-1. If |trigger|'s [=attribution trigger/dedup key=] is not null, [=list/append=] it to |sourceToAttribute|'s
-    [=attribution source/dedup keys=].
+1. If |trigger|'s [=attribution trigger/client deduplication key=] is not null, [=list/append=] it to |sourceToAttribute|'s
+    [=attribution source/client deduplication keys=].
 1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
 
     : [=attribution rate-limit record/source site=]
@@ -892,7 +892,7 @@ To <dfn>obtain a report</dfn> given an [=attribution source=] |source| and an [=
     :: |trigger|'s [=attribution trigger/trigger time=].
     : [=attribution report/source identifier=]
     :: |source|'s [=attribution source/source identifier=].
-    : [=attribution report/report id=]
+    : [=attribution report/server deduplication key=]
     :: The result of [=generating a random UUID=].
 1. Return |report|.
 
@@ -937,12 +937,12 @@ To <dfn>serialize an [=attribution report=]</dfn> |report|, run the following st
     :: |report|'s [=attribution report/event id=], [=serialize an integer|serialized=]
     : "`trigger_data`"
     :: |report|'s [=attribution report/trigger data=], [=serialize an integer|serialized=]
-    : "`report_id`"
-    :: |report|'s [=attribution report/report id=]
+    : "`server_deduplication_key`"
+    :: |report|'s [=attribution report/server deduplication key=]
 
 1. Return the [=byte sequence=] resulting from executing [=serialize an infra value to JSON bytes=] on |data|.
 
-Note: The inclusion of "`report_id`" in the report body is intended to allow the report recipient
+Note: The inclusion of "`server_deduplication_key`" in the report body is intended to allow the report recipient
 to perform deduplication and prevent double counting, in the event that the user agent retries
 reports on failure. To prevent the report recipient from learning additional information about
 whether a user is online, retries should be limited in number and subject to random delays.


### PR DESCRIPTION
Fixes #281


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/282.html" title="Last updated on Jan 10, 2022, 5:14 PM UTC (eeb9f3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/282/b6d5f63...apasel422:eeb9f3a.html" title="Last updated on Jan 10, 2022, 5:14 PM UTC (eeb9f3a)">Diff</a>