### PR TITLE
Use correct probability in report JSON

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -322,7 +322,7 @@ probabilities:
 
 ```jsonc
 {
-  "randomized_trigger_rate": 0.24,
+  "randomized_trigger_rate": 0.0024,
   ...
 }
 ```


### PR DESCRIPTION
The probability is expressed as a value in the range [0, 1], not a percentage.