### PR TITLE
Flesh out the noise corrector

### DIFF
--- a/noise_corrector.py
+++ b/noise_corrector.py
@@ -1,66 +1,169 @@
 #!/usr/bin/env python3
 
+import argparse
 import collections
+from datetime import timedelta
+import itertools
 import json
-import math
 import numpy
 import random
+from typing import List, Hashable
 
-# This file provides functionality to correct noisy data coming from the event-level reports in the Attribution Reporting API. The output is an estimate of what the real report distribution looks like.
-# Call `correct_nav_sources` and `correct_event_sources` to correct noisy reports⏤respectively click reports and view reports.
-# Under the hood, both these functions use `estimate_true_values`; this function applies mathematical operations to correct noisy data coming from the event-level reports. 
-# This file also includes additional utilities for enumerating the possible outputs from various parametrizations
-# of the event-level reports.
-# - `get_possible_nav_source_outputs`
-# - `get_possible_event_source_outputs`
-# - `generate_possible_outputs_per_source`
+# This file provides functionality to correct noisy data coming from the event-level reports in the Attribution Reporting API.
 
 
 # Noise rate values are taken from the EVENT.md explainer:
 # https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#data-limits-and-noise
 
-RANDOMIZED_RESPONSE_RATE_EVENT_SOURCES = .0000025
-RANDOMIZED_RESPONSE_RATE_NAV_SOURCES = .0024
+################## GENERIC UTILITIES ##################
 
-def run_example():
-  ################ EXAMPLE ################
-  # This example runs sample data through a simulation of the randomized
-  # response, and applies the noise correction to it.
+class ParamConfig:
+  def __init__(self,
+               randomized_reponse_rate,
+               trigger_data_cardinality,
+               max_reports,
+               max_windows,
+               name):
+    self.rr_rate = randomized_reponse_rate
+    self.data_cardinality = trigger_data_cardinality
+    self.max_reports = max_reports
+    self.max_windows = max_windows
+    self.name = name
 
-  # Optional (added here to help understanding of this example): get all the possible outputs
-  outputs = get_possible_event_source_outputs()
-  true_reports = [
-      100_000_000,  # Sources with no reports
-      100_000,  # Sources with trigger (conversion) data "0"
-      40_000,  # Sources with trigger (conversion) data "1"
-  ]
-  # Simulate what the noisy reports produced by the browser would look like
-  noisy_reports = simulate_randomization(
-      true_reports, RANDOMIZED_RESPONSE_RATE_EVENT_SOURCES)
-  # Generate the noise-corrected reports 
-  # To use this script in a real system, replace `noisy_reports` with the actual attribution reports received by the endpoint (and sent from users' browsers).
-  # Note how `noisy_reports` is NOT a list of reports; it's an array of counts of reports of each kind
-  # For example, for view reports: `noisy_reports = [42, 10, 13]` would mean that among the 147 views that you recorded: 42 of them resulted in no report, 10 of them resulted in a report with trigger data 0, and 13 of them in a report with trigger data 1
-  corrected_reports = correct_event_sources(noisy_reports)
 
-  # Print the result in a tabular form
-  column_names = ["Output", "True count", "Noisy count", "Corrected count"]
-  print("{:<30}{:<20}{:<20}{:<20}".format(*column_names))
-  for i, v in enumerate(corrected_reports):
-    d = json.dumps(outputs[i])
-    print(f"{d:<30}{true_reports[i]:<20,}{noisy_reports[i]:<20,}{v:<20,.1f}")
+NAV_PARAMS = ParamConfig(.5, 8, 3, 3, "navigation")
+EVENT_PARAMS = ParamConfig(.0000025, 2, 1, 1, "event")
+
+
+class OutputEnumeration:
+  # Class encapsulating logic which represents the logical output of the API
+  # per source event, for the purposes of debiasing the randomized response
+  # privacy mechanism.
+  def __init__(self, report_tuple, params: ParamConfig):
+    """report_tuple must be in the form ((window_index, trigger_data),...)"""
+    self.output = tuple(sorted(report_tuple))
+    self.params = params
+
+  def __str__(self):
+    def report_to_string(r):
+      if r is None:
+        return "No report"
+      return {"window": r[0], "data": r[1]}
+    return json.dumps([report_to_string(r) for r in self.output])
+
+  def __repr__(self): return self.output.__repr__()
+  def __hash__(self): return self.output.__hash__()
+
+  # Needed to support instances in dictionaries
+  def __eq__(self, other): return self.output.__eq__(other.output)
+  def __lt__(self, other): return self.output.__lt__(other.output)
+
+  @classmethod
+  def create_null(cls, params: ParamConfig):
+    return cls((), params)
+
+  @classmethod
+  def create_from_data(cls, source_with_reports):
+    """Create an output directly from structured data
+
+    source_with_reports: list of (source, [report, ...]) tuples.
+    See get_conversion_counts for expected structure for sources and reports.
+    """
+    source, reports = source_with_reports
+    params = EVENT_PARAMS if source["source_type"] == "event" else NAV_PARAMS
+    max_reports = params.max_reports
+    assert len(reports) <= max_reports
+    return cls(tuple(OutputEnumeration._parse_report(source, r) for r in reports),
+               params)
+
+  @classmethod
+  def generate_all(cls, params: ParamConfig):
+    all_single_reports = list(itertools.product(range(params.max_windows),
+                                                range(params.data_cardinality)))
+    all_reports_ordered = []
+    for r in range(params.max_reports + 1):
+      reports = itertools.product(*(r * [all_single_reports]))
+      all_reports_ordered.extend(list(reports))
+    # Simulate shuffling within a reporting window by sorting and deduping
+    deduped = set([tuple(sorted(x)) for x in all_reports_ordered])
+    return sorted([cls(x, params) for x in deduped])
+
+  def data_histogram(self):
+    """Returns the number of reports associated with this output, broken
+    out by the trigger_data"""
+
+    histogram = numpy.zeros(self.params.data_cardinality)
+    for r in self.output:
+      histogram[r[1]] += 1
+    return histogram
+
+  def get_report_time(self, window: int, source: dict):
+    expiry = source["registration_config"]["expiry"]
+    if self.params.name == "event":
+      return expiry
+
+    # TODO(csharrison): This assumes the expiry > 7 days.
+    windows = [timedelta(days=2), timedelta(days=7), timedelta(seconds=expiry)]
+    source_time = source["source_time"]
+    return int(source_time + windows[window].total_seconds())
+
+  def generate_reports_for_source(self, source: dict):
+    assert self.params.name == source["source_type"]
+    source_event_id = source["registration_config"]["source_event_id"]
+
+    reports = []
+    for window, trigger_data in self.output:
+      reports.append({
+          "report_time": self.get_report_time(window, source),
+          "report": {
+              "source_event_id": source_event_id,
+              "source_type": self.params.name,
+              "trigger_data": str(trigger_data)
+          }
+      })
+      return reports
+
+  @staticmethod
+  def _parse_report(source, report: dict):
+    window_index = OutputEnumeration._get_window_index_for_report(
+        source, report)
+    trigger_data = int(report["report"]["trigger_data"])
+    return (window_index, trigger_data)
+
+  @staticmethod
+  def _get_window_index_for_report(source: dict, report: dict):
+    if source["source_type"] == "event":
+      return 0
+
+    report_time = report["report_time"]
+    source_time = source["source_time"]
+    raw_expiry = source["registration_config"]["expiry"]
+    expiry = timedelta(seconds=int(raw_expiry))
+    delta = timedelta(seconds=report_time - source_time)
+
+    # Navigation sources have 3 possible reporting windows.
+    # TODO(csharrison): this assumes that the expiry > 7 days. This should be
+    # updated to be more robust.
+    assert expiry > timedelta(days=7)
+    if delta >= expiry:
+      return 2
+    if delta >= timedelta(days=7):
+      return 1
+    return 0
 
 
 # Estimates the true values for data generated through k-ary randomized
 # response. The estimator should be unbiased.
-def estimate_true_values(observed_values, randomized_response_rate, beta=0):
+def estimate_true_values(observed_values: dict, randomized_response_rate: float):
   """Returns a list of corrected counts
 
-  observed_values: A list of size `k` for k-ary randomized response, where the
-    ith value in the list indicates the counts of the ith output (out of k).
+  observed_values: A map of size `k` for k-ary randomized response. Each item
+                   represents a randomized response output as the key, with its
+                   associated count as the value.
+
   randomized_response_rate: The probability any given output is randomized
   """
-  n = sum(observed_values)
+  n = sum(observed_values.values())
   k = len(observed_values)
   x = randomized_response_rate
 
@@ -71,149 +174,226 @@ def estimate_true_values(observed_values, randomized_response_rate, beta=0):
   # Which matches formula 6 after applying a multiplication of `n` to transform
   # rates to counts.
   def estimate(v):
-    return (v -  n * x / k) / (1 - x)
+    return (v - n * x / k) / (1 - x)
 
-  return [estimate(v) for v in observed_values]
+  return {k: estimate(v) for k, v in observed_values.items()}
 
 
-def generate_possible_outputs_per_source(max_reports, data_cardinality,
-                                         max_windows):
-  """Enumerates all possible outputs for any given source event
+def join_reports_with_sources(sources: dict, reports: dict):
+  """Returns tuple of (source, [reports]) joined with the source_event_id"""
+  report_map = collections.defaultdict(list)
+  for r in reports["reports"]:
+    report_map[r["report"]["source_event_id"]].append(r)
 
-  max_reports: The maximum number of triggers that can be attributed to this
-                source.
-  data_cardinality: The number of possible trigger_data values for the source.
-  max_windows: The number of reporting windows any given report can show up in.
+  def join(source):
+    source_event_id = source['registration_config']['source_event_id']
+    return (source, report_map[source_event_id])
+  return [join(s) for s in sources['sources']]
 
-  Returns: a JSON list of all possible outputs. Each output is a list of size
-           `max_reports`, describing each report (its trigger_data and window).
+################## AGGREGATE UTILITIES ##################
+
+
+def print_data_histogram(hist: List[float], type: str):
+  print(f"Histogram of trigger_data for {type} sources:")
+  print("{:<20}{:<15}".format("trigger_data", "count"))
+  for i, count in enumerate(hist):
+    print(f"{i:<20}{count:.2f}")
+  print()
+
+
+def get_raw_corrected_map(joined: dict, params: ParamConfig):
+  output_counts = {o: 0 for o in OutputEnumeration.generate_all(params)}
+  for j in joined:
+    output = OutputEnumeration.create_from_data(j)
+    assert output in output_counts
+    output_counts[output] += 1
+
+  return estimate_true_values(output_counts, params.rr_rate)
+
+
+def correct_aggregates(joined: dict, params: ParamConfig):
+  corrected = get_raw_corrected_map(joined, params)
+  histogram = numpy.zeros(params.data_cardinality)
+  for o, c in corrected.items():
+    histogram += c * o.data_histogram()
+  return histogram
+
+
+################## EVENT-LEVEL UTILITIES ##################
+
+def adjust_to_match_distribution(values: Hashable, distribution: dict, default_value):
+  """Given a list of values, and an aggregate map that weights all possible values,
+  returns a list of adjusted values to match the distribution.
+
+  values: list of arbitrary objects (must be possible to place in dict/set). To
+          minimize bias, this list should be shuffled prior to calling this
+          method.
+  distribution: map of value -> estimated count. All values in `values` must be
+                present. Note that negatives are allowed, but it will mean the
+                output of the function will be biased.
+  default_value: a default / null value
+
+  The algorithm used in this method attempts to achieve two goals:
+  1. The output values match the distribution as much as possible, minimizing
+     bias.
+  2. The output maximizes "overlap" with the input. That is, satisfying (1), we
+     want to minimize the number of inputs that are adjusted.
   """
 
-  # TODO(csharrison): Consider just enumerating the reports directly vs.
-  # enumerating the k-combinations.
-  def find_k_comb(N, k):
-    """Computes the Nth lexicographically smallest k-combination
+  # Split the distribution into two chunks: elements with mass >= 1 and not.
+  # Clamp negatives to 0. Note this introduces bias, but it seems unavoidable.
+  large_elts = {k: v for k, v in distribution.items() if v >= 1}
+  small_elts = {k: max(0, v) for k, v in distribution.items() if v < 1}
+  assert len(small_elts) + len(large_elts) == len(distribution)
 
-    https://en.wikipedia.org/wiki/Combinatorial_number_system
+  def decrement_large_elt(elt):
+    large_elts[elt] -= 1
+    if large_elts[elt] < 1:
+      small_elts[elt] = large_elts[elt]
+      large_elts.pop(elt)
 
-    Follows the greedy algorithm outlined here:
-    http://math0.wvstateu.edu/~baker/cs405/code/Combinadics.html
+  def handle_value(val):
+    assert val in distribution and (val in small_elts or val in large_elts)
+    # Do not adjust s if there is mass in the aggregate distribution for it.
+    if val in large_elts:
+      decrement_large_elt(val)
+      return val
+
+    # Otherwise, pick from among the elements with enough mass for subtraction.
+    if len(large_elts) > 0:
+      elt = random.choices(list(large_elts.keys()), large_elts.values())[0]
+      decrement_large_elt(elt)
+      return elt
+
+    # Otherwise, sample with replacement from the small elts, with any leftover
+    # mass defaulting to a default value / null value. This also introduces
+    # small bias towards the null value bucket.
+    total_mass_remaining = sum(small_elts.values())
+    if random.random() <= total_mass_remaining:
+      return random.choices(list(small_elts.keys()), small_elts.values())[0]
+    return default_value
+
+  return [handle_value(v) for v in values]
+
+
+def generate_corrected_event_level(joined: dict, params: ParamConfig):
+  # Shuffle the input data. This is because the order of which values are
+  # considered in the loop below matters, because we adjust the distribution
+  # as we go. Shuffling first avoids favoring some values over others.
+  # Note: ideally adjust_to_match_distribution would shuffle, but it becomes
+  # more difficult to associate the adjustments with the input JSON.
+  random.shuffle(joined)
+  aggregates = get_raw_corrected_map(joined, params)
+  outputs = [OutputEnumeration.create_from_data(j) for j in joined]
+  adjusted_values = adjust_to_match_distribution(
+      outputs, aggregates, OutputEnumeration.create_null(params))
+
+  def adjust_json(j, unadjusted, adjusted):
+    source = j[0]
+    source_event_id = source['registration_config']['source_event_id']
+    adjusted_reports = adjusted.generate_reports_for_source(source)
+    return (source, adjusted_reports)
+
+  return [adjust_json(j, o, a) for j, o, a in zip(joined, outputs, adjusted_values)]
+
+
+def main():
+  DESCRIPTION = """\
+  noise_corrector.py is a command-line tool that attempts to debias the noise
+  output in the Attribution Reporting API for event-level reports. It takes as
+  input JSON files which represent source registrations and the resulting
+  event-level reports. It can provide corrected output in aggregate, or via
+  generating synthetic event-level data.
+
+  The noise added in the API is described at:
+  https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#data-limits-and-noise
+  """
+  parser = argparse.ArgumentParser(
+      description=DESCRIPTION, formatter_class=argparse.RawTextHelpFormatter)
+  SOURCE_HELP = """\
+  Required path to an input file containing sources, in the following JSON
+  format:
+  {
+    // List of zero or more sources.
+    "sources": [
+      {
+        // Required time at which to register the source in seconds since the
+        // UNIX epoch.
+        "source_time": 123,
+
+        // Required source type, either "navigation" or "event", corresponding to
+        // whether the source is registered on click or on view, respectively.
+        "source_type": "navigation",
+
+        "registration_config": {
+          // Required uint64 formatted as a base-10 string.
+          "source_event_id": "123456789",
+
+          // Optional int64 in milliseconds formatted as a base-10 string.
+          // Defaults to 30 days.
+          "expiry": "864000000",
+        }
+      },
+      ...
+    ]
+  }
     """
-    target = N
-    c = 0
-    while math.comb(c, k) <= N:
-      c += 1
+  parser.add_argument('--source_file', dest='source_file',
+                      type=open, help=SOURCE_HELP, required=True)
+  REPORT_HELP = """\
+  Required path to an input file containing reports, in the following JSON
+  format:
+  {
+    // List of zero or more reports.
+    reports: [
+      {
+        // Time at which the report would have been sent in seconds since the
+        // UNIX epoch.
+        "report_time": 123,
 
-    combos = []
-    while c >= 0 and k >= 0:
-      coef = math.comb(c, k)
-      if coef <= target:
-        combos.append(c)
-        k -= 1
-        target -= coef
-      c -= 1
-    return combos
+        // The report itself.
+        "report": {
+          "source_event_id": "1337",
+          "source_type": "navigation",
 
-  def bars_to_report(star_index, num_star):
-    """Returns a report description of the form:
-    {
-      "window": <window index>,
-      "trigger_data": <trigger data>
-    }
+          // Coarse data set in the attribution trigger registration
+          "trigger_data": "4"
+        }
+      },
+      ...
+    ]
+  }
     """
+  parser.add_argument('--report_file', dest='report_file',
+                      type=open, help=REPORT_HELP, required=True)
 
-    bars_prior_to_star = star_index - (max_reports - 1 - num_star)
+  OUTPUT_MODE_HELP = """\
+  Optional. One of `event-level` or `aggregate`. Defaults to `aggregate`, which
+  provides aggregate counts for different trigger metadata values. The
+  `event-level` mode outputs synthetic sources and their associated reports
+  matching the debiased aggregate data as best as possible.
+  """
+  parser.add_argument('--output_mode', dest='output_mode',
+                      choices=['event-level', 'aggregate'],
+                      default='aggregate', help=OUTPUT_MODE_HELP)
 
-    # Any stars before any bars means the report is suppressed.
-    if bars_prior_to_star == 0:
-      return "No report"
+  args = parser.parse_args()
 
-    # Otherwise, the number of bars just indexes into the cartesian product
-    # of |data_cardinality| x |num_windows|.
-    # Subtract the first bar because that just begins the first window.
-    window, data = divmod(bars_prior_to_star - 1, data_cardinality)
-    return {"window": window, "trigger_data": data}
+  source_json = json.load(args.source_file)
+  report_json = json.load(args.report_file)
+  joined = join_reports_with_sources(source_json, report_json)
+  navs = [s for s in joined if s[0]["source_type"] == "navigation"]
+  events = [s for s in joined if s[0]["source_type"] == "event"]
+  if args.output_mode == 'aggregate':
+    nav_histogram = correct_aggregates(navs, NAV_PARAMS)
+    event_histogram = correct_aggregates(events, EVENT_PARAMS)
+    print_data_histogram(nav_histogram, "navigation")
+    print_data_histogram(event_histogram, "event")
 
-  def generate_output(N):
-    star_indices = find_k_comb(N, max_reports)
-    return [bars_to_report(s, i) for i, s in enumerate(star_indices)]
+  elif args.output_mode == 'event-level':
+    nav_corrected = generate_corrected_event_level(navs, NAV_PARAMS)
+    print(json.dumps(nav_corrected))
 
-  star_bar_length = data_cardinality * max_windows + max_reports
-  num_sequences = math.comb(star_bar_length, max_reports)
-  return [generate_output(i) for i in range(num_sequences)]
-
-
-def get_possible_event_source_outputs():
-  """Returns the possible outputs for an event source"""
-  # event_sources are when a user views an ad
-  max_reports_event_sources = 1
-  # view source events id can be up to one bit i.e. their value is one the 2 values
-  data_cardinality_event_sources = 2
-  # for views, there's only one reporting window
-  max_windows_event_sources = 1
-  return generate_possible_outputs_per_source(max_reports_event_sources,
-                                              data_cardinality_event_sources,
-                                              max_windows_event_sources)
-
-
-def get_possible_nav_source_outputs():
-  """Returns all the possible outputs for navigation source"""
-  # nav_sources are when a user clicks on an ad.
-  max_reports_nav_sources = 3
-  # Navigation source id can be up to 3 bits i.e. their value is one of 8
-  # values.
-  data_cardinality_nav_sources = 8
-  # for clicks, there are 3 reporting windows.
-  max_windows_nav_sources = 3
-  return generate_possible_outputs_per_source(max_reports_nav_sources,
-                                              data_cardinality_nav_sources,
-                                              max_windows_nav_sources)
-
-
-# Params are taken from the EVENT.md explainer:
-# https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#data-limits-and-noise
-def correct_event_sources(observed_values):
-  # For event sources, there should be 3 possible observed values:
-  # No triggers, 1 trigger with trigger (conversion) data 0, 1 trigger with trigger (conversion) data 1.
-  assert len(observed_values) == 3
-  return estimate_true_values(observed_values,
-                              RANDOMIZED_RESPONSE_RATE_EVENT_SOURCES)
-
-
-def correct_nav_sources(observed_values):
-  # For navigation sources, there should be 2925 possible observed values. The
-  # reasion for this is fairly complicated. The output for a given source has a
-  # one-to-one mapping with a "stars and bars" sequence of `max_reports` stars
-  # and `max_windows * data_cardinality` bars. Thus the number of possible
-  # outputs is given by (num_stars + num_bars choose num_bars) = (27 choose 3) =
-  # 2925.
-  # https://en.wikipedia.org/wiki/Stars_and_bars_(combinatorics)
-  assert len(observed_values) == 2925
-  return estimate_true_values(observed_values,
-                              RANDOMIZED_RESPONSE_RATE_NAV_SOURCES)
-
-
-def simulate_randomization(true_reports, randomized_response_rate):
-  """Simulates randomized response on true_reports; this simulates the way the
-  browser would treat reports in an idealized system (e.g. no rate limits hit,
-  etc)."""
-  n = sum(true_reports)
-  k = len(true_reports)
-  noisy_reports = [0] * k
-
-  # This method could be implemented by doing randomized response on every
-  # individual true report. However, we can optimize this by directly computing
-  # the number of total responses that would have flipped, and uniformly
-  # distributing them across all k buckets.
-  x = randomized_response_rate
-
-  # Compute the non-flipped counts.
-  non_flipped_counts = [numpy.random.binomial(true_count, 1 - x) for true_count in true_reports]
-
-  # Distribute the flipped reports uniformly among all k buckets.
-  num_flipped = n - sum(non_flipped_counts)
-  flipped_counts = numpy.random.multinomial(num_flipped, [1/k] * k)
-  return non_flipped_counts + flipped_counts
 
 if __name__ == "__main__":
-  run_example()
+  main()

--- a/noise_corrector.py
+++ b/noise_corrector.py
@@ -3,7 +3,6 @@
 import argparse
 import collections
 from datetime import timedelta
-import itertools
 import json
 import numpy
 import random

--- a/noise_corrector.py
+++ b/noise_corrector.py
@@ -366,42 +366,42 @@ def main():
   {
     "input": {
       // List of zero or more sources.
-      'sources': [
+      "sources": [
         {
           // Required time at which to register the source in seconds since the
           // UNIX epoch.
-          'source_time': 123,
+          "source_time": 123,
 
-          // Required source type, either 'navigation' or 'event', corresponding to
+          // Required source type, either "navigation" or "event", corresponding to
           // whether the source is registered on click or on view, respectively.
-          'source_type': 'navigation',
+          "source_type": "navigation",
 
-          'registration_config': {
+          "registration_config": {
             // Required uint64 formatted as a base-10 string.
-            'source_event_id': '123456789',
+            "source_event_id": "123456789",
 
             // Optional int64 in milliseconds formatted as a base-10 string.
             // Defaults to 30 days.
-            'expiry': '864000000',
+            "expiry": 864000000,
           }
         },
         ...
       ]
     },
     // List of zero or more reports.
-    reports: [
+    "reports": [
       {
         // Time at which the report would have been sent in seconds since the
         // UNIX epoch.
-        'report_time': 123,
+        "report_time": 123,
 
         // The report itself.
-        'report': {
-          'source_event_id': '1337',
-          'source_type': 'navigation',
+        "report": {
+          "source_event_id": "1337",
+          "source_type": "navigation",
 
           // Coarse data set in the attribution trigger registration
-          'trigger_data': '4'
+          "trigger_data": "4"ß
         }
       },
       ...
@@ -424,16 +424,17 @@ def main():
                       default='single', help=INPUT_MODE_HELP)
 
   OUTPUT_MODE_HELP = '''\
-  Optional. One of `event-level` or `aggregate`. Defaults to `aggregate`, which
-  provides aggregate counts for different trigger data values. The
-  `event-level` mode outputs synthetic sources and their associated reports
-  matching the debiased aggregate data as best as possible. In other words, the
-  tool will mutate the input reports in some way (sometimes by generating new
-  reports that were not input into the system) so that the output event-level
-  data, when aggregated, matches the data that `aggregate` mode would return.
+  Optional. One of `experimental-event-level` or `aggregate`. Defaults to
+  `aggregate`, which provides aggregate counts for different trigger data
+  values. The `experimental-event-level` mode outputs synthetic sources and
+  their associated reports matching the debiased aggregate data as best as
+  possible. In other words, the tool will mutate the input reports in some way
+  (sometimes by generating new reports that were not input into the system) so
+  that the output event-level data, when aggregated, matches the data that
+  `aggregate` mode would return.
 
-  Note: the `event-level` format is experimental. More work is needed to make
-  sure the use-cases for it are well-understood.
+  Note: the `experimental-event-level` format is experimental. More work is
+  needed to make sure the use-cases for it are well-understood.
 
   `aggregate` output format:
   {
@@ -453,7 +454,7 @@ def main():
     ]
   }
 
-  `event-level` output format:
+  `experimental-event-level` output format:
   [
     {
       "source": <source, same as input format>
@@ -463,7 +464,7 @@ def main():
   ]
   '''
   parser.add_argument('--output_mode', dest='output_mode',
-                      choices=['event-level', 'aggregate'],
+                      choices=['experimental-event-level', 'aggregate'],
                       default='aggregate', help=OUTPUT_MODE_HELP)
 
   parser.add_argument('-v', '--version', action='version', version=VERSION)
@@ -489,7 +490,7 @@ def main():
         'event': correct_aggregates(events, EVENT_PARAMS),
     }, indent=2))
 
-  elif args.output_mode == 'event-level':
+  elif args.output_mode == 'experimental-event-level':
     nav_corrected = generate_corrected_event_level(list(navs), NAV_PARAMS)
     event_corrected = generate_corrected_event_level(list(events), EVENT_PARAMS)
     combined = [{'source': s, 'reports': r}


### PR DESCRIPTION
This PR massively overhauls the noise corrector. It has turned into a fully fledged command line utility that takes as input JSON files of sources and reports.

Given JSON inputs of event-level sources and reports, It provides two types of outputs:
1. Aggregate output: The tool aggregates event-level reports and reports de-biased histograms broken out by the trigger_data, in an unbiased way.
2. Event-level output: The tool synthesizer adjusted event-level data to match (as best as possible) the de-biased aggregates

Fixes #301

Note this utility is designed to be interoperable with the JSON formats in the WIP [Chromium API simulator](https://source.chromium.org/chromium/chromium/src/+/main:tools/attribution_reporting/) in the following way:
```
    +-----------+ +------------+
    |Source JSON| |Trigger JSON|
    +-----+---+-+ +-----+------+
          |   |         |
          |  +v---------v--+
          |  |             |
          |  |  Simulator  |
          |  |             |
          |  +-------+-----+
          |          |
          |    +-----v-----+
          |    |Report JSON|
          |    +--+--------+
          |       |
  +-------v-------v-+
  |                 |
  | Noise Corrector |
  |                 |
  +-----+----------++
        |          |
+-------v---+ +----v-------+
| Corrected | | Corrected  |
| Aggregates| | Report JSON|
+-----------+ +------------+
```
Edit: given crrev.com/c/3459831 it should also be possible for the simulator to input data directly to the noise corrector too.