### PR TITLE
Use an enum for debug_mode

### DIFF
--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -255,7 +255,7 @@ Note: if [debugging](https://github.com/WICG/conversion-measurement-api/blob/mai
 is enabled, additional debug fields will be present in aggregatable reports,
 including the cleartext payloads, to allow downstream systems to verify that
 reports are constructed correctly. If debugging is enabled, the `shared_info` 
-will include the flag `debug_mode: "enabled"` to allow the aggregation service
+will include the flag `"debug_mode": "enabled"` to allow the aggregation service
 to support debugging functionality on debug reports.
 
 ### Contribution bounding and budgeting

--- a/AGGREGATE.md
+++ b/AGGREGATE.md
@@ -255,8 +255,8 @@ Note: if [debugging](https://github.com/WICG/conversion-measurement-api/blob/mai
 is enabled, additional debug fields will be present in aggregatable reports,
 including the cleartext payloads, to allow downstream systems to verify that
 reports are constructed correctly. If debugging is enabled, the `shared_info` 
-will include the flag `debug_mode: 1` to allow the aggregation service to 
-support debugging functionality on debug reports.
+will include the flag `debug_mode: "enabled"` to allow the aggregation service
+to support debugging functionality on debug reports.
 
 ### Contribution bounding and budgeting
 


### PR DESCRIPTION
Currently, 1 is used as a sentinel value, but an enum would allow us to support multiple options in the future if necessary.