### PR TITLE
Remove redundant prefixes from source and trigger priority JSON fields

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -157,7 +157,7 @@ configures the API:
   "source_event_id": "12340873456",
   "destination": "[eTLD+1]",
   "expiry": "[64-bit signed integer]",
-  "source_priority": "[64-bit signed integer]"
+  "priority": "[64-bit signed integer]"
 }
 ```
 
@@ -172,10 +172,10 @@ limited to 64 bits of information but the value can vary.
 deleted. Default is 30 days, with a maximum value of 30 days. The maximum expiry
 can also vary between browsers. This will be rounded to the nearest day.
 
--   `source_priority`: (optional) a signed 64-bit integer used to prioritize
+-   `priority`: (optional) a signed 64-bit integer used to prioritize
 this source with respect to other matching sources. When a trigger redirect is
 received, the browser will find the matching source with highest
-`source_priority` value and generate a report. The other sources will not
+`priority` value and generate a report. The other sources will not
 generate reports.
 
 Once this header is received, the browser will proceed with [handling an
@@ -334,7 +334,7 @@ reflect a final set of parameters.
 When the browser receives an attribution trigger redirect on a URL matching the
 `destination` eTLD+1, it looks up all sources in storage that match
 <`attributionsrc` origin, `destination`> and picks the one with the greatest
-`source_priority`. If multiple sources have the greatest `source_priority`, the
+`priority`. If multiple sources have the greatest `priority`, the
 browser picks the one that was stored most recently.
 
 The browser then schedules a report for the source that was picked by storing

--- a/EVENT.md
+++ b/EVENT.md
@@ -261,7 +261,7 @@ about how to treat the trigger event:
 ```jsonc
 [{
     "trigger_data": "[unsigned 64-bit integer, but the browser will sanitize it down to 3 bits]",
-    "trigger_priority": "[signed 64-bit integer]",
+    "priority": "[signed 64-bit integer]",
     "deduplication_key": "[unsigned 64-bit integer]"
 }]
 ```
@@ -269,7 +269,7 @@ TODO: Consider moving this over to a structured header. See [issue
 194](https://github.com/WICG/conversion-measurement-api/issues/194).
 
 - `trigger_data`: optional coarse-grained data to identify the triggering event.
-- `trigger_priority`: optional signed 64-bit integer representing the priority
+- `priority`: optional signed 64-bit integer representing the priority
 of this trigger compared to other triggers for the same source.
 - `deduplication_key`: optional unsigned 64-bit integer which will be used to
 deduplicate multiple triggers which contain the same deduplication_key for a
@@ -339,7 +339,7 @@ browser picks the one that was stored most recently.
 
 The browser then schedules a report for the source that was picked by storing
  {`attributionsrc` origin, `destination` eTLD+1, `source_event_id`,
- [decoded](#data-encoding) `trigger_data`, `trigger_priority`, `deduplication_key`} for
+ [decoded](#data-encoding) `trigger_data`, `priority`, `deduplication_key`} for
  the source. Scheduled reports will be sent as detailed in [Sending scheduled
  reports](#sending-scheduled-reports).
 


### PR DESCRIPTION
These fields are already contained in a source- or trigger-registration JSON document, so the `source_` and `trigger_` prefixes are redundant.