### PR TITLE
Replace attribution rate-limit source-type scope with reporting endpoint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -413,8 +413,8 @@ An attribution rate-limit record is a [=struct=] with the following items:
 :: A [=site=].
 : <dfn>attribution destination</dfn>
 :: A [=site=].
-: <dfn>source type</dfn>
-:: Either "<code>navigation</code>" or "<code>event</code>".
+: <dfn>reporting endpoint</dfn>
+:: An [=url/origin=].
 : <dfn>trigger time</dfn>
 :: A point in time.
 
@@ -741,7 +741,7 @@ Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToA
 1. Let |matchingRateLimitRecords| be all entries in the [=attribution rate-limit cache=] where all of the following are true:
      * entry's [=attribution rate-limit record/source site=] and |sourceSite| are equal
      * entry's [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal
-     * entry's [=attribution rate-limit record/source type=] and |sourceToAttribute|'s [=attribution source/source type=] are equal
+     * entry's [=attribution rate-limit record/reporting endpoint=] and |trigger|'s [=attribution trigger/reporting endpoint=] are equal
      * entry's [=attribution rate-limit record/trigger time=] is at least [=attribution rate-limit window=] before |trigger|'s [=attribution trigger/trigger time=]
 1. If the [=list/size=] of |matchingRateLimitRecords| is greater than or equal to [=max attributions per rate-limit window=], return <strong>blocked</strong>.
 1. Return <strong>allowed</strong>.
@@ -752,7 +752,7 @@ rate-limiting window for attribution.
 <dfn>Max attributions per rate-limit window</dfn> is a vendor-specific integer that controls
 the maximum number of attributions for a ([=attribution rate-limit record/source site=],
 [=attribution rate-limit record/attribution destination=],
-[=attribution rate-limit record/source type=]) per [=attribution rate-limit window=].
+[=attribution rate-limit record/reporting endpoint=]) per [=attribution rate-limit window=].
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 
@@ -812,8 +812,8 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
     :: The result of [=obtain a site|obtaining a site=] from |sourceToAttribute|'s [=attribution source/source origin=].
     : [=attribution rate-limit record/attribution destination=]
     :: |attributionDestination|
-    : [=attribution rate-limit record/source type=]
-    :: |sourceToAttribute|'s [=attribution source/source type=]
+    : [=attribution rate-limit record/reporting endpoint=]
+    :: |sourceToAttribute|'s [=attribution source/reporting endpoint=]
     : [=attribution rate-limit record/trigger time=]
     :: |trigger|'s [=attribution trigger/trigger time=]
 1. Add |rateLimitRecord| to the [=attribution rate-limit cache=].


### PR DESCRIPTION
https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#reporting-cooldown--rate-limits

#386


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/387.html" title="Last updated on Apr 27, 2022, 6:10 PM UTC (4d1014a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/387/c4231c8...apasel422:4d1014a.html" title="Last updated on Apr 27, 2022, 6:10 PM UTC (4d1014a)">Diff</a>