### PR TITLE
Default to off for high risk contexts

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -217,8 +217,8 @@ Policy](https://w3c.github.io/webappsec-permissions-policy/):
 </iframe>
 ```
 
-The API will be enabled by default in the top-level context and in same-origin
-children. Any script running in these contexts can declare a source with any
+The API will be diabled by default so that web site authors can turn it on only for pages
+where it presents an acceptable level of risk. Any script running in these contexts can declare a source with any
 reporting origin. Publishers who wish to explicitly disable the API for all
 parties can do so via an [HTTP
 header](https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-http-header-field).


### PR DESCRIPTION
Publishers will need to check pages for level of user risk before activating. Set the permission policy to default off, so that high risk tracking is less likely to happen  accidentally before this review.

See https://github.com/patcg/private-measurement/issues/6