### PR TITLE
Specify reporting-origin limits for source registrations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -422,13 +422,15 @@ An attribution report is a [=struct=] with the following items:
 An attribution rate-limit record is a [=struct=] with the following items:
 
 <dl dfn-for="attribution rate-limit record">
+: <dfn>scope</dfn>
+:: Either "`source`" or "`attribution`".
 : <dfn>source site</dfn>
 :: A [=site=].
 : <dfn>attribution destination</dfn>
 :: A [=site=].
 : <dfn>reporting endpoint</dfn>
 :: An [=url/origin=].
-: <dfn>trigger time</dfn>
+: <dfn>time</dfn>
 :: A point in time.
 
 </dl>
@@ -634,6 +636,23 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. [=list/Remove=] all entries in |cache| where the entry's [=attribution source/expiry time=] is less than the current time.
 1. If the [=list/size=] of |cache| is greater than or equal to the user agent's
      [=max source cache size=], return.
+1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
+    : [=attribution rate-limit record/scope=]
+    :: "`source`"
+    : [=attribution rate-limit record/source site=]
+    :: |source|'s [=attribution source/source site=]
+    : [=attribution rate-limit record/attribution destination=]
+    :: |source|'s [=attribution source/attribution destination=]
+    : [=attribution rate-limit record/reporting endpoint=]
+    :: |source|'s [=attribution source/reporting endpoint=]
+    : [=attribution rate-limit record/time=]
+    :: |source|'s [=attribution source/source time=]
+1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
+    |rateLimitRecord| is <strong>blocked</strong>, return.
+1. Add |rateLimitRecord| to the [=attribution rate-limit cache=].
+1. Remove all entries from the [=attribution rate-limit cache=] whose
+    [=attribution rate-limit record/time=] is at least [=attribution rate-limit window=]
+    before the current time.
 1. If |source|'s [=attribution source/attribution mode=][0] is "`falsely`", then:
     1. Assert: |source|'s [=attribution source/source type=] is "`event`".
     1. If the [=list/size=] of the [=attribution report cache=] is greater than or equal to the user
@@ -767,11 +786,12 @@ To <dfn>match an attribution source's filter data against an attribution trigger
 
 Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToAttribute|:
 
-1. Let |matchingRateLimitRecords| be all entries in the [=attribution rate-limit cache=] where all of the following are true:
-     * entry's [=attribution rate-limit record/source site=] and |sourceToAttribute|'s [=attribution source/source site=] are equal
-     * entry's [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal
-     * entry's [=attribution rate-limit record/reporting endpoint=] and |trigger|'s [=attribution trigger/reporting endpoint=] are equal
-     * entry's [=attribution rate-limit record/trigger time=] is at least [=attribution rate-limit window=] before |trigger|'s [=attribution trigger/trigger time=]
+1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
+     * |record|'s [=attribution rate-limit record/scope=] is "`attribution`"
+     * |record|'s [=attribution rate-limit record/source site=] and |sourceToAttribute|'s [=attribution source/source site=] are equal
+     * |record|'s [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal
+     * |record|'s [=attribution rate-limit record/reporting endpoint=] and |trigger|'s [=attribution trigger/reporting endpoint=] are equal
+     * |record|'s [=attribution rate-limit record/time=] is at least [=attribution rate-limit window=] before |trigger|'s [=attribution trigger/trigger time=]
 1. If |matchingRateLimitRecords|'s [=list/size=] is greater than or equal to [=max attributions per rate-limit window=], return <strong>blocked</strong>.
 1. Return <strong>allowed</strong>.
 
@@ -783,27 +803,40 @@ the maximum number of attributions for a ([=attribution rate-limit record/source
 [=attribution rate-limit record/attribution destination=],
 [=attribution rate-limit record/reporting endpoint=]) per [=attribution rate-limit window=].
 
-<h3 dfn id="should-block-attribution-for-reporting-endpoint-limit">Should attribution be blocked by reporting-endpoint limit</h3>
+<h3 dfn id="should-block-processing-for-reporting-endpoint-limit">Should processing be blocked by reporting-endpoint limit</h3>
 
-Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToAttribute|:
+Given an [=attribution rate-limit record=] |newRecord|:
 
-1. Let |matchingRateLimitRecords| be all entries in the [=attribution rate-limit cache=] where all of the following are true:
-     * entry's [=attribution rate-limit record/source site=] and |sourceToAttribute|'s [=attribution source/source site=] are equal
-     * entry's [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal
-     * entry's [=attribution rate-limit record/trigger time=] is at least [=attribution rate-limit window=] before |trigger|'s [=attribution trigger/trigger time=]
+1. Let |max| be [=max source reporting endpoints per rate-limit window=].
+1. If |newRecord|'s [=attribution rate-limit record/scope=] is "`attribution`", set |max| to
+     [=max attribution reporting endpoints per rate-limit window=].
+1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
+     * |record|'s [=attribution rate-limit record/scope=] and |newRecord|'s [=attribution rate-limit record/scope=] are equal
+     * |record|'s [=attribution rate-limit record/source site=] and |newRecord|'s [=attribution rate-limit record/source site=] are equal
+     * |record|'s [=attribution rate-limit record/attribution destination=] and |newRecord|'s [=attribution rate-limit record/attribution destination=] are equal
+     * |record|'s [=attribution rate-limit record/time=] is at least [=attribution rate-limit window=] before |newRecord|'s [=attribution rate-limit record/time=]
 1. Let |distinctReportingEndpoints| be a new empty [=ordered set=].
 1. [=map/iterate|For each=] |record| of |matchingRateLimitRecords|, [=set/append=] |record|'s
      [=attribution rate-limit record/reporting endpoint=] to |distinctReportingEndpoints|.
-1. If |distinctReportingEndpoints| [=list/contains=] |trigger|'s
-     [=attribution trigger/reporting endpoint=], return <strong>allowed</strong>.
-1. If |distinctReportingEndpoints|'s [=list/size=] is greater than or equal to
-     [=max attribution reporting endpoints per rate-limit window=], return <strong>blocked</strong>.
+1. If |distinctReportingEndpoints| [=list/contains=] |newRecord|'s
+    [=attribution rate-limit record/reporting endpoint=], return <strong>allowed</strong>.
+1. If |distinctReportingEndpoints|'s [=list/size=] is greater than or equal to |max|, return
+    <strong>blocked</strong>.
 1. Return <strong>allowed</strong>.
 
-<dfn>Max attribution reporting endpoints per rate-limit window</dfn> is a vendor-specific integer
-that controls the maximum number of distinct reporting endpoints for a
+<dfn>Max source reporting endpoints per rate-limit window</dfn> is a vendor-specific integer
+that controls the maximum number of distinct
+[=attribution source/reporting endpoint|reporting endpoints=] for a
 ([=attribution rate-limit record/source site=],
-[=attribution rate-limit record/attribution destination=]) which can create [=attribution reports=] per [=attribution rate-limit window=].
+[=attribution rate-limit record/attribution destination=]) that can create [=attribution sources=]
+per [=attribution rate-limit window=].
+
+<dfn>Max attribution reporting endpoints per rate-limit window</dfn> is a vendor-specific integer
+that controls the maximum number of distinct
+[=attribution trigger/reporting endpoint|reporting endpoints=] for a
+([=attribution rate-limit record/source site=],
+[=attribution rate-limit record/attribution destination=]) that can create [=attribution reports=]
+per [=attribution rate-limit window=].
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 
@@ -834,8 +867,19 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
     [=max reports per attribution destination=], return.
 1. If the result of running [=should attribution be blocked by rate limit=] with |trigger| and
     |sourceToAttribute| is <strong>blocked</strong>, return.
-1. If the result of running [=should attribution be blocked by reporting-endpoint limit=] with
-    |trigger| and |sourceToAttribute| is <strong>blocked</strong>, return.
+1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
+    : [=attribution rate-limit record/scope=]
+    :: "`attribution`"
+    : [=attribution rate-limit record/source site=]
+    :: |sourceToAttribute|'s [=attribution source/source site=]
+    : [=attribution rate-limit record/attribution destination=]
+    :: |attributionDestination|
+    : [=attribution rate-limit record/reporting endpoint=]
+    :: |sourceToAttribute|'s [=attribution source/reporting endpoint=]
+    : [=attribution rate-limit record/time=]
+    :: |trigger|'s [=attribution trigger/trigger time=]
+1. If the result of running [=should processing be blocked by reporting-endpoint limit=] with
+    |rateLimitRecord| is <strong>blocked</strong>, return.
 1. Let |report| be the result of running [=obtain a report=] with |sourceToAttribute| and |trigger|.
 1. If |sourceToAttribute|'s [=attribution source/number of reports=] value is equal to the
     user agent's [=max reports per source=] value, then:
@@ -862,19 +906,9 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
 1. Increment |sourceToAttribute|'s [=attribution source/number of reports=] value by 1.
 1. If |trigger|'s [=attribution trigger/dedup key=] is not null, [=list/append=] it to |sourceToAttribute|'s
     [=attribution source/dedup keys=].
-1. Let |rateLimitRecord| be a new [=attribution rate-limit record=] with the items:
-
-    : [=attribution rate-limit record/source site=]
-    :: |sourceToAttribute|'s [=attribution source/source site=]
-    : [=attribution rate-limit record/attribution destination=]
-    :: |attributionDestination|
-    : [=attribution rate-limit record/reporting endpoint=]
-    :: |sourceToAttribute|'s [=attribution source/reporting endpoint=]
-    : [=attribution rate-limit record/trigger time=]
-    :: |trigger|'s [=attribution trigger/trigger time=]
 1. Add |rateLimitRecord| to the [=attribution rate-limit cache=].
 1. Remove all entries from the [=attribution rate-limit cache=] whose
-    [=attribution rate-limit record/trigger time=] is at least [=attribution rate-limit window=]
+    [=attribution rate-limit record/time=] is at least [=attribution rate-limit window=]
     before the current time.
 
 <dfn>Max reports per attribution destination</dfn> is a vendor-specific integer which controls how

--- a/index.bs
+++ b/index.bs
@@ -786,7 +786,7 @@ To <dfn>match an attribution source's filter data against an attribution trigger
 
 Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToAttribute|:
 
-1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record|  of [=attribution rate-limit cache=] where all of the following are true:
+1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| of [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is "`attribution`"
      * |record|'s [=attribution rate-limit record/source site=] and |sourceToAttribute|'s [=attribution source/source site=] are equal
      * |record|'s [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal

--- a/index.bs
+++ b/index.bs
@@ -786,7 +786,7 @@ To <dfn>match an attribution source's filter data against an attribution trigger
 
 Given an [=attribution trigger=] |trigger| and [=attribution source=] |sourceToAttribute|:
 
-1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record| in the [=attribution rate-limit cache=] where all of the following are true:
+1. Let |matchingRateLimitRecords| be all [=attribution rate-limit records=] |record|  of [=attribution rate-limit cache=] where all of the following are true:
      * |record|'s [=attribution rate-limit record/scope=] is "`attribution`"
      * |record|'s [=attribution rate-limit record/source site=] and |sourceToAttribute|'s [=attribution source/source site=] are equal
      * |record|'s [=attribution rate-limit record/attribution destination=] and |trigger|'s [=attribution trigger/attribution destination=] are equal


### PR DESCRIPTION
https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#reporting-cooldown--rate-limits

#386


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/394.html" title="Last updated on May 5, 2022, 8:39 PM UTC (b405cdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/394/7ef99b5...apasel422:b405cdb.html" title="Last updated on May 5, 2022, 8:39 PM UTC (b405cdb)">Diff</a>