### PR TITLE
Replace code elements with backticks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -90,7 +90,7 @@ Add the following <a spec=html>content attributes</a> to the <{a}> element:
 : <{a/attributionsourcepriority}>
 :: The priority of this source relative to other sources when triggering attribution
 : <{a/registerattributionsource}>
-:: Registers an [=attribution source=] with a source type "<code>event</code>"
+:: Registers an [=attribution source=] with a source type "`event`"
 
 Extend the <{a}> element's <a spec=html>DOM interface</a> to include the following interface:
 
@@ -135,7 +135,7 @@ will always be attributed to the source with the highest priority value that has
 and [=attribution source/attribution destination=].
 
 The <dfn for="a" element-attr>registerattributionsource</dfn> attribute, if present, registers an
-additional source whose [=attribution source/source type=] is "<code>event</code>".
+additional source whose [=attribution source/source type=] is "`event`".
 
 Note: One simple priority scheme would be to use the current millisecond timestamp as the priority value.
 
@@ -214,10 +214,10 @@ to set the [=navigation params/attribution source=] of |navigationParams| to |at
 
 <h4 id="monkeypatch-document-creation">Document creation</h4>
 
-At the time <a spec="html">create and initialize a <code>Document</code> object</a> is invoked, the user agent knows the final URL used for the
+At the time <a spec="html">create and initialize a `Document` object</a> is invoked, the user agent knows the final URL used for the
 navigation and can validate the [=attribution source/attribution destination=].
 
-In <a spec="html">create and initialize a <code>Document</code> object</a>, before
+In <a spec="html">create and initialize a `Document` object</a>, before
 
 > 2. Let permissionsPolicy be the result of creating a permissions policy from a response given browsingContext
 >     ...
@@ -282,7 +282,7 @@ partial interface Window {
 </pre>
 
 The
-<dfn method for=AttributionReporting><code>registerAttributionSource(<var>params</var>)</code></dfn>
+<dfn method for=AttributionReporting>`registerAttributionSource(<var>params</var>)`</dfn>
 method steps are:
 
 1. Let |source| be the result of running [=obtain an attribution source from params=] with |params|
@@ -298,7 +298,7 @@ finer-grained detail about other errors that occurred during the [=process an at
 step.
 
 # Permissions Policy integration # {#permission-policy-integration}
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn>attribution-reporting</dfn></code>". Its [=default allowlist=] is *.
+This specification defines a [=policy-controlled feature=] identified by the string "`<dfn>attribution-reporting</dfn>`". Its [=default allowlist=] is *.
 
 # Structures # {#structures}
 
@@ -329,7 +329,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>reporting endpoint</dfn>
 :: An [=url/origin=].
 : <dfn>source type</dfn>
-:: Either "<code>navigation</code>" or "<code>event</code>".
+:: Either "`navigation`" or "`event`".
 : <dfn>expiry</dfn>
 :: A length of time.
 : <dfn>priority</dfn>
@@ -385,7 +385,7 @@ An attribution report is a [=struct=] with the following items:
 : <dfn>event id</dfn>
 :: A non-negative 64-bit integer.
 : <dfn>source type</dfn>
-:: Either "<code>navigation</code>" or "<code>event</code>".
+:: Either "`navigation`" or "`event`".
 : <dfn>trigger data</dfn>
 :: A non-negative 64-bit integer.
 : <dfn>randomized trigger rate</dfn>
@@ -498,7 +498,7 @@ and a double |randomPickRate|:
 1. Return the result of [=obtaining a randomized response=] with the [=attribution mode=]
     (`"truthfully"`, null), |possibleValues|, and |randomPickRate|.
 
-<h3 algorithm id="obtaining-attribution-source-anchor">Obtaining an attribution source from an <code>a</code> element</h3>
+<h3 algorithm id="obtaining-attribution-source-anchor">Obtaining an attribution source from an `a` element</h3>
 
 To <dfn>obtain an attribution source from an anchor</dfn> given an <{a}> element |anchor|:
 
@@ -517,7 +517,7 @@ To <dfn>obtain an attribution source from an anchor</dfn> given an <{a}> element
 1. Return the result of running [=obtain an attribution source from params=] with |params| and
     |anchor|'s [=relevant settings object=].
 
-<h3 algorithm id="obtaining-event-attribution-source-anchor">Obtaining an event attribution source from an <code>a</code> element</h3>
+<h3 algorithm id="obtaining-event-attribution-source-anchor">Obtaining an event attribution source from an `a` element</h3>
 
 To <dfn>obtain an event attribution source from an anchor</dfn> given an <{a}> element |anchor|, run the following steps:
 
@@ -635,7 +635,7 @@ To <dfn>process an attribution source</dfn> given an [=attribution source=] |sou
 1. If the [=list/size=] of |cache| is greater than or equal to the user agent's
      [=max source cache size=], return.
 1. If |source|'s [=attribution source/attribution mode=][0] is "`falsely`", then:
-    1. Assert: |source|'s [=attribution source/source type=] is "<code>event</code>".
+    1. Assert: |source|'s [=attribution source/source type=] is "`event`".
     1. If the [=list/size=] of the [=attribution report cache=] is greater than or equal to the user
         agent's [=max report cache size=], return.
     1. Let |fakeTrigger| be a new [=attribution trigger=] with the items:
@@ -898,7 +898,7 @@ can be associated with a source event id. Larger values allow for more attributi
 To <dfn>obtain a report delivery time</dfn> given an [=attribution source=] |source| and a
 [=attribution trigger/trigger time=] |triggerTime|, perform the following steps. They
 return a point in time.
-1. If |source|'s [=attribution source/source type=] is "<code>event</code>", return |source|'s
+1. If |source|'s [=attribution source/source type=] is "`event`", return |source|'s
      [=attribution source/expiry time=] + 1 hour.
 1. Let |timeToTrigger| be the difference between
     |triggerTime| and [=attribution source/source time=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/396.html" title="Last updated on May 3, 2022, 1:57 PM UTC (87c0c32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/396/54a3a50...apasel422:87c0c32.html" title="Last updated on May 3, 2022, 1:57 PM UTC (87c0c32)">Diff</a>