### PR TITLE
Replace report-attribution URL path with report-event-attribution

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1024,7 +1024,7 @@ To <dfn>generate a report URL</dfn> for a given [=attribution report=] |report|,
 1. Set |reportUrl|'s [=url/scheme=] to |reportingOrigin|'s [=origin/scheme=].
 1. Set |reportUrl|'s [=url/host=] to |reportingOrigin|'s [=origin/host=].
 1. Set |reportUrl|'s [=url/port=] to |reportingOrigin|'s [=origin/port=].
-1. Set |reportUrl|'s [=url/path=] to «"`.well-known`", "`attribution-reporting`", "`report-attribution`"».
+1. Set |reportUrl|'s [=url/path=] to «"`.well-known`", "`attribution-reporting`", "`report-event-attribution`"».
 1. Return |reportUrl|.
 
 <h3 id="issue-report-request">Issuing a report request</h3>


### PR DESCRIPTION
https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#attribution-reports

#386


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/403.html" title="Last updated on May 3, 2022, 6:24 PM UTC (6aa8f0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/403/7ef99b5...apasel422:6aa8f0d.html" title="Last updated on May 3, 2022, 6:24 PM UTC (6aa8f0d)">Diff</a>