### PR TITLE
Allow max attributions per source to vary by source type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -837,8 +837,11 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
 1. If the result of running [=should attribution be blocked by reporting-endpoint limit=] with
     |trigger| and |sourceToAttribute| is <strong>blocked</strong>, return.
 1. Let |report| be the result of running [=obtain a report=] with |sourceToAttribute| and |trigger|.
-1. If |sourceToAttribute|'s [=attribution source/number of reports=] value is equal to the
-    user agent's [=max reports per source=] value, then:
+1. Let |maxAttributionsPerSource| be the user agent's [=max attributions per navigation source=].
+1. If |sourceToAttribute|'s [=attribution source/source type=] is "`event`", set
+    |maxAttributionsPerSource| to the user agent's [=max attributions per event source=].
+1. If |sourceToAttribute|'s [=attribution source/number of reports=] value is equal to
+    |maxAttributionsPerSource|, then:
     1. Let |matchingReports| be all entries in the [=attribution report cache=] where all of the following are true:
          * entry's [=attribution report/report time=] and |report|'s [=attribution report/report time=] are equal.
          * entry's [=attribution report/source identifier=] [=string/is=] |report|'s [=attribution report/source identifier=]
@@ -881,7 +884,13 @@ To <dfn>trigger attribution</dfn> given an [=attribution trigger=] |trigger| run
 many [=attribution reports=] can be in the [=attribution report cache=] for an
 [=attribution report/attribution destination=].
 
-<dfn>Max reports per source</dfn> is a vendor-specific integer which controls how many [=attribution reports=] can be created for an [=attribution source=].
+<dfn>Max attributions per navigation source</dfn> is a vendor-specific integer that controls how
+many times a single [=attribution source=] whose [=attribution source/source type=] is
+"`navigation`" can be attributed.
+
+<dfn>Max attributions per event source</dfn> is a vendor-specific integer that controls how
+many times a single [=attribution source=] whose [=attribution source/source type=] is "`event`"
+can be attributed.
 
 <dfn>Max report cache size</dfn> is a vendor-specific integer which controls how many
 [=attribution reports=] can be in the [=attribution report cache=].


### PR DESCRIPTION
https://github.com/WICG/conversion-measurement-api/blob/main/EVENT.md#triggering-attribution

#386


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/405.html" title="Last updated on May 3, 2022, 7:25 PM UTC (206a74e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/405/5644d23...apasel422:206a74e.html" title="Last updated on May 3, 2022, 7:25 PM UTC (206a74e)">Diff</a>