### PR TITLE
Specify aggregatable histogram creation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -353,7 +353,7 @@ An attribution source is a [=struct=] with the following items:
 : <dfn>debug key</dfn>
 :: Null or a non-negative 64-bit integer.
 : <dfn>aggregatable source</dfn>
-:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and [=map/value|values=] are
+:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose [=map/value|values=] are
     non-negative 128-bit integers.
 
 </dl>
@@ -384,7 +384,7 @@ An attribution aggregatable trigger is a [=struct=] with the following items:
 : <dfn>trigger data</dfn>
 :: A [=list=] of [=attribution aggregatable trigger data=].
 : <dfn>values</dfn>
-:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and [=map/value|values=] are
+:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and whose [=map/value|values=] are
     non-negative 32-bit integers.
 
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -352,6 +352,38 @@ An attribution source is a [=struct=] with the following items:
 :: An [=attribution filter map=].
 : <dfn>debug key</dfn>
 :: Null or a non-negative 64-bit integer.
+: <dfn>aggregatable source</dfn>
+:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and [=map/value|values=] are
+    non-negative 128-bit integers.
+
+</dl>
+
+<h3 dfn-type=dfn>Attribution aggregatable trigger data</h3>
+
+An attribution aggregatable trigger data is a [=struct=] with the following items:
+
+<dl dfn-for="attribution aggregatable trigger data">
+: <dfn>key piece</dfn>
+:: A non-negative 128-bit integer.
+: <dfn>source keys</dfn>
+:: An [=ordered set=] of [=strings=].
+: <dfn>filters</dfn>
+:: An [=attribution filter map=].
+: negated filters
+:: An [=attribution filter map=].
+
+</dl>
+
+<h3 dfn-type=dfn>Attribution aggregatable trigger</h3>
+
+An attribution aggregatable trigger is a [=struct=] with the following items:
+
+<dl dfn-for="attribution aggregatable trigger">
+: <dfn>trigger data</dfn>
+:: A [=list=] of [=attribution aggregatable trigger data=].
+: <dfn>values</dfn>
+:: An [=ordered map=] whose [=map/key|keys=] are [=strings=] and [=map/value|values=] are
+    non-negative 32-bit integers.
 
 </dl>
 
@@ -378,6 +410,8 @@ An attribution trigger is a [=struct=] with the following items:
 :: An [=attribution filter map=].
 : <dfn>debug key</dfn>
 :: Null or a non-negative 64-bit integer.
+: <dfn>aggregatable trigger</dfn>
+:: An [=attribution aggregatable trigger=].
 
 </dl>
 
@@ -414,6 +448,18 @@ An attribution report is a [=struct=] with the following items:
 :: Null or a non-negative 64-bit integer.
 : <dfn>trigger debug key</dfn>
 :: Null or a non-negative 64-bit integer.
+
+</dl>
+
+<h3 dfn-type=dfn>Attribution aggregatable histogram</h3>
+
+An attribution aggregatable histogram is a [=struct=] with the following items:
+
+<dl dfn-for="attribution aggregatable histogram">
+: <dfn>key</dfn>
+:: A non-negative 128-bit integer.
+: <dfn>value</dfn>
+:: A non-negative 32-bit integer.
 
 </dl>
 
@@ -837,6 +883,32 @@ that controls the maximum number of distinct
 ([=attribution rate-limit record/source site=],
 [=attribution rate-limit record/attribution destination=]) that can create [=attribution reports=]
 per [=attribution rate-limit window=].
+
+<h3 algorithm id="creating-aggregatable-histograms">Creating aggregatable histograms</h3>
+
+To create [=attribution aggregatable histograms=] given an [=attribution source=] |source| and an
+ [=attribution trigger=] |trigger|, run the following steps:
+
+1. Let |aggregationKeys| be |source|'s [=attribution source/aggregatable source=].
+1. Let |aggregatableTrigger| be |trigger|'s [=attribution trigger/aggregatable trigger=].
+1. [=list/iterate|For each=] |triggerData| of |aggregatableTrigger|'s [=attribution aggregatable trigger/trigger data=]:
+    1. If the result of running [=match an attribution source's filter  data against an attribution trigger=] with
+        |source| and |triggerData|'s [=attribution aggregatable trigger data/filters=] is false, [=iteration/continue=].
+    1. [=set/iterate|For each=] |sourceKey| of |triggerData|'s [=attribution aggregatable trigger data/source keys=]:
+        1. If |aggregationKeys|[|sourceKey|] does not [=map/exist=], [=iteration/continue=].
+        1. Set |aggregationKeys|[|sourceKey|] to |aggregationKeys|[|sourceKey|] XOR |triggerData|'s
+            [=attribution aggregatable trigger data/key piece=].
+1. Let |aggregatableValues| be |aggregatableTrigger|'s [=attribution aggregatable trigger/values=].
+1. Let |histograms| be a new empty [=list=].
+1. [=map/iterate|For each=] |id| → |key| of |aggregationKeys|:
+    1. If |aggregatableValues|[|id|] does not [=map/exist=], [=iteration/continue=].
+    1. Let |histogram| be a new [=attribution aggregatable histogram=] with the items:
+        : [=attribution aggregatable histogram/key=]
+        :: |key|
+        : [=attribution aggregatable histogram/value=]
+        :: |aggregatableValues|[|id|]
+    1. [=list/Append=] |histogram| to |histograms|.
+1. Return |histograms|.
 
 <h3 algorithm id="triggering-attribution">Triggering attribution</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -369,10 +369,12 @@ An attribution aggregatable trigger data is a [=struct=] with the following item
 :: An [=ordered set=] of [=strings=].
 : <dfn>filters</dfn>
 :: An [=attribution filter map=].
-: negated filters
+: <dfn>negated filters</dfn>
 :: An [=attribution filter map=].
 
 </dl>
+
+Issue: Use [=attribution aggregatable trigger data/negated filters=] in [=create attribution aggregatable histograms=].
 
 <h3 dfn-type=dfn>Attribution aggregatable trigger</h3>
 
@@ -886,7 +888,7 @@ per [=attribution rate-limit window=].
 
 <h3 algorithm id="creating-aggregatable-histograms">Creating aggregatable histograms</h3>
 
-To create [=attribution aggregatable histograms=] given an [=attribution source=] |source| and an
+To <dfn>create [=attribution aggregatable histograms=]</dfn> given an [=attribution source=] |source| and an
  [=attribution trigger=] |trigger|, run the following steps:
 
 1. Let |aggregationKeys| be |source|'s [=attribution source/aggregatable source=].


### PR DESCRIPTION
Spec the algorithm to create aggregatable histograms from attribution source and trigger. 

Note that filters logic depends on https://github.com/WICG/conversion-measurement-api/pull/402 and negated filters logic is not included yet and will be addressed later.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/pull/416.html" title="Last updated on May 9, 2022, 6:30 PM UTC (2b45f48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/416/ae0fc40...2b45f48.html" title="Last updated on May 9, 2022, 6:30 PM UTC (2b45f48)">Diff</a>