### PR TITLE
Rename registerAttributionSource to registerSource and delete implementation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -263,7 +263,7 @@ dictionary AttributionSourceParams {
 
 [Exposed=Window, SecureContext]
 interface AttributionReporting {
-  Promise&lt;undefined&gt; registerAttributionSource(AttributionSourceParams params);
+  Promise&lt;undefined&gt; registerSource(USVString url);
 };
 
 [SecureContext]
@@ -273,20 +273,12 @@ partial interface Window {
 </pre>
 
 The
-<dfn method for=AttributionReporting><code>registerAttributionSource(<var>params</var>)</code></dfn>
+<dfn method for=AttributionReporting><code>registerSource(<var>url</var>)</code></dfn>
 method steps are:
 
-1. Let |source| be the result of running
-    [=obtain an attribution source from params=] with |params|, "`event`",
-    and the [=relevant settings object=] of [=this=].
-1. If |source| is null, return [=a promise rejected with=] the {{undefined}} value.
-1. [=Queue a task=] to [=process an attribution source=] with |source|.
 1. Return [=a promise resolved with=] the {{undefined}} value.
 
-Note: This function returns a promise even though the promise is always resolved or rejected by the
-time the function returns; in the future, the promise might be resolved with a value that provides
-finer-grained detail about other errors that occurred during the [=process an attribution source=]
-step.
+Issue: Implement this method.
 
 # Permissions Policy integration # {#permission-policy-integration}
 This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn>attribution-reporting</dfn></code>". Its [=default allowlist=] is *.


### PR DESCRIPTION
We will spec this later on alongside the other attributionsrc surfaces.

#386


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/424.html" title="Last updated on May 11, 2022, 1:38 PM UTC (ae7917a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/424/183c928...apasel422:ae7917a.html" title="Last updated on May 11, 2022, 1:38 PM UTC (ae7917a)">Diff</a>