### PR TITLE
Generalize overview of spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -35,18 +35,26 @@ for cross-site identifiers like third-party cookies.
 
 ## Overview ## {#overview}
 
-A page can register an [=attribution source=] on a site by providing
- <{a/attributionsourceeventid}> and <{a/attributiondestination}> attributes on an <{a}> element.
-When such an <{a}> element is clicked, and the resulting navigation commits in a document within the [=same site=] as
-the <{a/attributiondestination}>, the [=attribution source=] is stored in UA storage.
+Pages/embedded sites are given the ability to register [=attribution sources=] and 
+[=attribution triggers=] can be linked by the User Agent to generate and 
+send [=attribution reports=] which contain information from both of those
+events.
 
-At a later point, the <{a/attributiondestination}> site may fire an HTTP request to
-trigger attribution, which matches an [=attribution trigger=] with any previously
-stored sources. If a matching source exists, it is scheduled to be
-reported at a later time, possibly multiple days in the future.
+A reporter, `https://reporter.example` embedded on `https://source.example` is able to
+measure whether an iteraction on the page lead to an action on `https://destination.example` 
+by registering an [=attribution source=] with a [=attribution source/destination=] of 
+`https://destination.example`. Reporters are able to register sources through a varity
+of surfaces, but ultimately requires the reporter to provide the User Agent with a
+HTTP-response header which starts attribution.
 
-Reports are sent to reporting endpoints that are configured in the attribution source
-and attribution trigger.
+At a later point in time, the reporter, now embedded on `https://destination.example`
+may register an [=attribution trigger=]. Internally, the User Agent attempts to match
+the trigger to previously regsitered source events based on where the sources/triggers were 
+registered and configurations provided by the reporter.
+
+If the User Agent is able to attribute the trigger to a source, it will generate and
+send an [=attribution report=] to the reporter via an HTTP POST request.
+
 
 
 # HTML monkeypatches # {#html-monkeypatches}

--- a/index.bs
+++ b/index.bs
@@ -42,7 +42,7 @@ send [=attribution reports=] which contain information from both of those events
 A reporter `https://reporter.example` embedded on `https://source.example` is able to
 measure whether an iteraction on the page lead to an action on `https://destination.example` 
 by registering an [=attribution source=] with an [=attribution source/attribution destination=] 
-of `https://destination.example`. Reporters are able to register sources through a varity
+of `https://destination.example`. Reporters are able to register sources through a variety
 of surfaces, but ultimately the reporter is required to provide the User Agent with a
 HTTP-response header which starts attribution.
 

--- a/index.bs
+++ b/index.bs
@@ -36,19 +36,19 @@ for cross-site identifiers like third-party cookies.
 ## Overview ## {#overview}
 
 Pages/embedded sites are given the ability to register [=attribution sources=] and 
-[=attribution triggers=] can be linked by the User Agent to generate and 
+[=attribution triggers=], which can be linked by the User Agent to generate and 
 send [=attribution reports=] which contain information from both of those events.
 
-A reporter, `https://reporter.example` embedded on `https://source.example` is able to
+A reporter `https://reporter.example` embedded on `https://source.example` is able to
 measure whether an iteraction on the page lead to an action on `https://destination.example` 
 by registering an [=attribution source=] with a [=attribution source/attribution destination=] 
 of `https://destination.example`. Reporters are able to register sources through a varity
-of surfaces, but ultimately requires the reporter to provide the User Agent with a
+of surfaces, but ultimately the reporter is required to provide the User Agent with a
 HTTP-response header which starts attribution.
 
-At a later point in time, the reporter, now embedded on `https://destination.example`
+At a later point in time, the reporter, now embedded on `https://destination.example`,
 may register an [=attribution trigger=]. Internally, the User Agent attempts to match
-the trigger to previously regsitered source events based on where the sources/triggers were 
+the trigger to previously registered source events based on where the sources/triggers were 
 registered and configurations provided by the reporter.
 
 If the User Agent is able to attribute the trigger to a source, it will generate and

--- a/index.bs
+++ b/index.bs
@@ -47,13 +47,14 @@ of surfaces, but ultimately the reporter is required to provide the User Agent w
 HTTP-response header which allows the source to be eligible for attribution.
 
 At a later point in time, the reporter, now embedded on `https://destination.example`,
-may register an [=attribution trigger=]. Triggers are registered by via an
-HTTP-response header from the reporter. Internally, the User Agent attempts to match
-the trigger to previously registered source events based on where the sources/triggers were 
-registered and configurations provided by the reporter.
+may register an [=attribution trigger=]. Reporters can register triggers by sending an
+HTTP-response header containing information about the action/event that occurred. Internally,
+the User Agent attempts to match the trigger to previously registered source events based on 
+where the sources/triggers were registered and configurations provided by the reporter.
 
 If the User Agent is able to attribute the trigger to a source, it will generate and
-send an [=attribution report=] to the reporter via an HTTP POST request.
+send an [=attribution report=] to the reporter via an HTTP POST request at a later point
+in time.
 
 
 # HTML monkeypatches # {#html-monkeypatches}

--- a/index.bs
+++ b/index.bs
@@ -41,7 +41,7 @@ send [=attribution reports=] which contain information from both of those events
 
 A reporter `https://reporter.example` embedded on `https://source.example` is able to
 measure whether an iteraction on the page lead to an action on `https://destination.example` 
-by registering an [=attribution source=] with a [=attribution source/attribution destination=] 
+by registering an [=attribution source=] with an [=attribution source/attribution destination=] 
 of `https://destination.example`. Reporters are able to register sources through a varity
 of surfaces, but ultimately the reporter is required to provide the User Agent with a
 HTTP-response header which starts attribution.

--- a/index.bs
+++ b/index.bs
@@ -37,13 +37,12 @@ for cross-site identifiers like third-party cookies.
 
 Pages/embedded sites are given the ability to register [=attribution sources=] and 
 [=attribution triggers=] can be linked by the User Agent to generate and 
-send [=attribution reports=] which contain information from both of those
-events.
+send [=attribution reports=] which contain information from both of those events.
 
 A reporter, `https://reporter.example` embedded on `https://source.example` is able to
 measure whether an iteraction on the page lead to an action on `https://destination.example` 
-by registering an [=attribution source=] with a [=attribution source/destination=] of 
-`https://destination.example`. Reporters are able to register sources through a varity
+by registering an [=attribution source=] with a [=attribution source/attribution destination=] 
+of `https://destination.example`. Reporters are able to register sources through a varity
 of surfaces, but ultimately requires the reporter to provide the User Agent with a
 HTTP-response header which starts attribution.
 
@@ -54,7 +53,6 @@ registered and configurations provided by the reporter.
 
 If the User Agent is able to attribute the trigger to a source, it will generate and
 send an [=attribution report=] to the reporter via an HTTP POST request.
-
 
 
 # HTML monkeypatches # {#html-monkeypatches}

--- a/index.bs
+++ b/index.bs
@@ -37,17 +37,18 @@ for cross-site identifiers like third-party cookies.
 
 Pages/embedded sites are given the ability to register [=attribution sources=] and 
 [=attribution triggers=], which can be linked by the User Agent to generate and 
-send [=attribution reports=] which contain information from both of those events.
+send [=attribution reports=] containing information from both of those events.
 
 A reporter `https://reporter.example` embedded on `https://source.example` is able to
 measure whether an iteraction on the page lead to an action on `https://destination.example` 
 by registering an [=attribution source=] with an [=attribution source/attribution destination=] 
 of `https://destination.example`. Reporters are able to register sources through a variety
-of surfaces, but ultimately the reporter is required to provide the User Agent with a
-HTTP-response header which starts attribution.
+of surfaces, but ultimately the reporter is required to provide the User Agent with an
+HTTP-response header which allows the source to be eligible for attribution.
 
 At a later point in time, the reporter, now embedded on `https://destination.example`,
-may register an [=attribution trigger=]. Internally, the User Agent attempts to match
+may register an [=attribution trigger=]. Triggers are registered by via an
+HTTP-response header from the reporter. Internally, the User Agent attempts to match
 the trigger to previously registered source events based on where the sources/triggers were 
 registered and configurations provided by the reporter.
 


### PR DESCRIPTION
This generalizes the spec overview to not focus on clicks / specific API surfaces given the number of different registration surfaces / report types currently in the explainer


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/pull/427.html" title="Last updated on May 12, 2022, 5:46 PM UTC (9dea016)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/427/6c3dbed...9dea016.html" title="Last updated on May 12, 2022, 5:46 PM UTC (9dea016)">Diff</a>