### PR TITLE
Remove window.attributionReporting.registerSource from spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -268,25 +268,7 @@ dictionary AttributionSourceParams {
   long long attributionExpiry;
   long long attributionSourcePriority;
 };
-
-[Exposed=Window, SecureContext]
-interface AttributionReporting {
-  Promise&lt;undefined&gt; registerSource(USVString url);
-};
-
-[SecureContext]
-partial interface Window {
-  readonly attribute AttributionReporting attributionReporting;
-};
 </pre>
-
-The
-<dfn method for=AttributionReporting><code>registerSource(<var>url</var>)</code></dfn>
-method steps are:
-
-1. Return [=a promise resolved with=] the {{undefined}} value.
-
-Issue: Implement this method.
 
 # Permissions Policy integration # {#permission-policy-integration}
 This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn>attribution-reporting</dfn></code>". Its [=default allowlist=] is *.


### PR DESCRIPTION
#386


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/conversion-measurement-api/pull/429.html" title="Last updated on May 18, 2022, 1:26 PM UTC (4ef0ac8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/conversion-measurement-api/429/d97d600...apasel422:4ef0ac8.html" title="Last updated on May 18, 2022, 1:26 PM UTC (4ef0ac8)">Diff</a>