### PR TITLE
Remove erroneous data-limit comment from event explainer

### DIFF
--- a/EVENT.md
+++ b/EVENT.md
@@ -273,7 +273,9 @@ about how to treat the trigger event:
 }]
 ```
 
-- `trigger_data`: optional coarse-grained data to identify the triggering event.
+- `trigger_data`: optional coarse-grained data to identify the triggering
+  event. The value will be limited to either 3 bits or 1 bit [depending on the
+  attributed source type](#data-limits-and-noise).
 - `priority`: optional signed 64-bit integer representing the priority
 of this trigger compared to other triggers for the same source.
 - `deduplication_key`: optional unsigned 64-bit integer which will be used to

--- a/EVENT.md
+++ b/EVENT.md
@@ -267,7 +267,7 @@ header `Attribution-Reporting-Register-Event-Trigger` which contains information
 about how to treat the trigger event:
 ```jsonc
 [{
-  "trigger_data": "[unsigned 64-bit integer, but the browser will sanitize it down to 3 bits]",
+  "trigger_data": "[unsigned 64-bit integer]",
   "priority": "[signed 64-bit integer]",
   "deduplication_key": "[unsigned 64-bit integer]"
 }]


### PR DESCRIPTION
Limits on trigger data are applied based on the type of the attributed source, which is discussed in the Data Limits section.